### PR TITLE
Ten weeks of Foreman fixes — reliability, lifecycle correctness, diagnostics

### DIFF
--- a/.ai-agent.example.json
+++ b/.ai-agent.example.json
@@ -32,5 +32,14 @@
   "maxTurns": 30,
   "maxDurationMs": 1800000,
   "logFormat": "text",
-  "logLevel": "info"
+  "logLevel": "info",
+
+  "_review_phase": "Optional. Enable the Review phase to auto-review feature PRs. Disabled by default. Requires EM_GITHUB_TOKEN in the environment. Per-repo override: add reviewEnabled to a repos[] entry.",
+  "reviewEnabled": false,
+  "emRepoPath": "../my-review-repo",
+  "reviewSkillPath": ".claude/skills/review-all-prs/SKILL.md",
+  "reviewModel": "claude-opus-4-8",
+  "reviewMaxTurns": 200,
+  "reviewMaxDurationMs": 3600000,
+  "reviewerLogin": "your-reviewer-bot-login"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ dist/
 .agent.pid
 .agent-state.json
 agent.log
+logs/
 .ai-agent.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,101 +1,106 @@
-# slashbin-ai-agent
+# slashbin-ai-agent (Foreman)
 
-Open-source daemon that implements GitHub issues using Claude Code CLI.
+Open-source daemon that drives GitHub work through Claude Code CLI: it implements
+approved issues, reviews the resulting PRs, revises them on feedback, and promotes
+merged work — across many repos from a single process.
 
-## Daemon Lifecycle
+## Cycle
+
+Each poll cycle runs six phases across every configured repo. Phases run in this
+order so labels set in one phase are consumed by the right phase next cycle:
 
 ```
-Poll GitHub ──► Find approved issues ──► Implement with Claude ──► Create PR ──►┐
-                                                                                 │
-┌────────────────────────────────────────────────────────────────────────────────┘
-│
-▼
-Watch PR for review feedback ──► Reviewer requests changes? ──► Yes ──►┐
-                                 │                                      │
-                                 ▼ No                                   │
-                          Keep watching                                 │
-                                                                        │
-┌───────────────────────────────────────────────────────────────────────┘
-│
-▼
-Comment "ACK — changes underway" ──► Spawn Claude to revise ──► Push changes
-──► Comment "Changes pushed, please review" ──► Back to watching
+Reconcile → Review → Revise → Implement → Branch Sync → Promote
 ```
 
-## Full Workflow
+1. **Reconcile** — detect orphaned commits on the feature branch with no PR; open one.
+2. **Review** *(opt-in, `reviewEnabled`)* — for repos with an open feature PR whose
+   linked issue is labeled `pr under review`, invoke a **review skill** that reviews,
+   merges clean PRs to the base branch, verifies, and transitions labels itself. Runs
+   first among PR-acting phases so it only acts on PRs labeled in a *prior* cycle
+   (labels settled → no same-cycle race). See **Review phase** below.
+3. **Revise** — for issues labeled `pr pending actions` with an open feature PR, invoke
+   the revision skill to address review feedback. Prioritized over new implementation.
+4. **Implement** — pick up `approved` issues with no delivering PR and invoke the
+   implementation skill; on success label the issue `pr under review`.
+5. **Branch Sync** — merge `main → develop` to clear post-promotion drift.
+6. **Promote** — create `develop → main` promotion PRs for `ready for prod release` issues.
 
-### Phase 1: Implementation
+Priority within a cycle is encoded by phase order. Only one Claude session runs at a
+time (`implementing` mutex) for git-state safety.
 
-1. **Poll** — every 5 minutes (configurable), query GitHub for open issues with the `approved` label that don't have a linked open PR
-2. **Skip** — issues labeled `blocked`, already implemented this session, or failed too many times (2 retries)
-3. **Implement** — spawn `claude --print` with the issue body as prompt. Claude reads the issue, implements, commits, pushes, and creates a PR
-4. **Track** — on success, extract the PR number from Claude's output and start watching it for review feedback
+## Review phase
 
-### Phase 2: Revision Cycle (priority over new implementations)
+The Review phase is categorically different from Implement/Revise, because review is a
+decision-layer workflow rather than an in-repo edit:
 
-Each poll cycle checks for pending revisions BEFORE looking for new issues.
+- **Runs in a separate review repo.** The review skill is spawned with its working
+  directory set to `emRepoPath` (not the service repo), so it has the reviewer's own
+  MCP servers, verification scripts, and context docs.
+- **Runs under a separate token.** Reviews/merges are attributed to `EM_GITHUB_TOKEN`
+  (distinct from `FOREMAN_GITHUB_TOKEN`) — reviewer identity ≠ implementer identity.
+- **Owns its own outcomes.** The skill posts the verdict, merges approved PRs, and
+  transitions issue labels itself; the orchestrator does **not** relabel afterward. Its
+  label side effects feed the other phases (approve → `ready for prod release` → Promote;
+  request-changes → `pr pending actions` → Revise).
 
-1. **Check tracked PRs** — for each PR the daemon created:
-   - If PR is closed/merged: remove from tracking
-   - If PR is approved: mark as approved, stop watching
-   - If PR has new review comments or changes requested: queue for revision
-2. **ACK** — comment on the PR: "Acknowledged — changes underway based on review feedback."
-3. **Revise** — spawn `claude --print` with:
-   - The review comments/feedback as context
-   - Instructions to `gh pr checkout <N>`, make changes, commit, push
-4. **Notify** — comment on PR: "Changes pushed addressing review feedback. Please review."
-5. **Track** — increment revision count, update last-addressed comment/review IDs
-6. **Max attempts** — after 3 revision rounds (configurable), comment "Maximum revision attempts reached. Manual intervention needed." and stop watching
+Gating (`findPRsNeedingReview`): an open `featureBranch → baseBranch` PR whose linked
+issue is `pr under review` (not `pr pending actions`) and with no review by
+`reviewerLogin` newer than the PR's latest commit (freshness guard against re-review
+loops). Every run's full turn-by-turn interaction (`--output-format stream-json`) is
+written to `logs/review/<repo>-cycle<N>-<ts>.log` for debugging.
 
-### Priority Order
+Disabled by default; opt in per repo with `reviewEnabled` and set `emRepoPath`. See
+README "Review phase (opt-in)" for the full config table.
 
-Each poll cycle:
-1. **Revisions first** — address reviewer feedback on existing PRs
-2. **New implementations** — pick up new approved issues only when no revisions are pending
+## State (persisted to disk)
 
-### Self-Loop Prevention
+Durable state lives in `.agent-state.json` in the daemon's directory (not the target
+repo), written after every change and loaded on startup so the daemon survives restarts.
 
-The daemon filters out its own comments and reviews when checking for new feedback. It identifies itself via `gh api user` (the authenticated gh user). This prevents the daemon from responding to its own ACK/completion comments.
+- `implemented` — issue numbers already delivered by a PR (self-heals when a tracked
+  entry has no delivering PR — see `docs/implemented-cache-self-heal.md`).
+- `skipped` — per-issue back-off records for issues the agent deliberately declined
+  (investigation-only, blocked-on-external-verification); cleared on success or after
+  the back-off window. Some transient skip reasons are re-checked and admitted early.
+- `failed` / failure counters — per-repo consecutive-failure counts with cooldown
+  (after `MAX_RETRIES` failures, skip the repo for `FAILURE_COOLDOWN_CYCLES`).
 
-### State (persisted to disk)
-
-All durable state is saved to `.agent-state.json` in the daemon's directory (not the target repo). This file is written after every state change and loaded on startup, so the daemon survives restarts.
-
-**Persisted:**
-- `implemented` — set of issue numbers already implemented
-- `failed` — map of issue numbers to failure count + last error
-- `trackedPRs` — map of PR numbers to revision state (count, last addressed IDs, status)
-
-**Transient (in-memory only):**
-- `implementing` / `revising` — mutex, only one operation at a time. Reset on restart (safe — the daemon just picks up where it left off next cycle).
+In-memory only: `implementing` mutex (reset on restart — safe).
 
 ## Architecture
 
 ```
 src/
-├── cli.ts           # CLI entry point (--once, --help, --version)
+├── cli.ts           # CLI entry point (--once, --repo, --help, --version)
 ├── config.ts        # Zod-validated config from .ai-agent.json + env vars
-├── logger.ts        # Structured logging (JSON/text, levels)
-├── github.ts        # GitHub polling via gh CLI (issues + PR reviews)
-├── agent.ts         # Spawns claude CLI (implement + revise)
-├── reviewer.ts      # PR tracking state machine (watch/revise/approved/abandoned)
+├── logger.ts        # Structured logging (JSON/text, levels, child contexts)
+├── github.ts        # gh-CLI helpers (issues, PRs, labels, branch drift, review gate)
+├── agent.ts         # Spawns claude CLI (implement / revise / review)
+├── reconciler.ts    # Orphaned-commit reconciliation + branch-divergence checks
 ├── state.ts         # Disk persistence (.agent-state.json)
-├── orchestrator.ts  # Priority-aware cycle: revisions > new implementations
-├── daemon.ts        # Poll loop + graceful shutdown
+├── orchestrator.ts  # 6-phase cycle, failure cooldowns, label transitions
+├── daemon.ts        # Poll loop, config hot-reload, Discord bridge, graceful shutdown
 └── index.ts         # Public API exports
 ```
 
 ## Prerequisites
 
-- `claude` CLI installed and authenticated (uses subscription, no API key)
-- `gh` CLI installed and authenticated (uses existing auth, no token)
+- `claude` CLI installed and authenticated
+- `gh` CLI installed; tokens supplied via env (`FOREMAN_GITHUB_TOKEN`; `EM_GITHUB_TOKEN`
+  when the Review phase is enabled)
 - Node.js >= 18
 
-## Key Design Decisions
+## Key design decisions
 
-- **Claude Code CLI over Agent SDK** — uses flat-rate subscription instead of per-run API costs
-- **gh CLI over Octokit** — uses existing machine auth, zero tokens to configure
-- **One at a time** — never runs two Claude instances concurrently (resource + git state safety)
-- **Revisions > new work** — always address reviewer feedback before picking up new issues
-- **Daemon manager** — `agent-manager.mjs` provides start/stop/restart/status/logs with PID tracking (same pattern as slashbin-discord-bot)
-- **Disk persistence** — `.agent-state.json` survives restarts; daemon resumes watching existing PRs and skips already-implemented issues
+- **Skills own the workflow; the Foreman just triggers.** Implement/revise/review logic
+  lives in skills (in the service repo for implement/revise, in `emRepoPath` for review),
+  not in TypeScript. The daemon discovers work, spawns Claude on the right skill, and
+  reconciles labels/state.
+- **One Claude session at a time** — resource + git-state safety.
+- **Phase order is the priority order** — reconcile and review settle prior-cycle state
+  before new implementation starts.
+- **Additive, opt-in config** — new capabilities (e.g. Review) default off so existing
+  `.ai-agent.json` files keep working unchanged.
+- **Disk persistence** — `.agent-state.json` survives restarts; the daemon resumes where
+  it left off.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For a single repo, set fields at the root level:
 | `featureBranch` | `AI_AGENT_FEATURE_BRANCH` | `features` | Branch to commit to |
 | `maxTurns` | `AI_AGENT_MAX_TURNS` | `30` | Max agent turns per issue |
 | `maxDurationMs` | `AI_AGENT_MAX_DURATION_MS` | `1800000` (30 min) | Max implementation time |
+| `model` | `AI_AGENT_MODEL` | CLI default | Model for implement/revise. Cascades to every repo that sets no `model` of its own |
 | `allowedTools` | — | `["Read","Write","Edit","Bash","Glob","Grep"]` | Tools the CLI can use |
 | `logFormat` | `AI_AGENT_LOG_FORMAT` | `text` | `json` or `text` |
 | `logLevel` | `AI_AGENT_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
@@ -315,7 +316,7 @@ Review config keys (all optional; global, with a per-repo `reviewEnabled` overri
 | `reviewEnabled` | `false` | Enable the Review phase (per-repo override supported) |
 | `emRepoPath` | — | Working dir for the review skill (the review repo). Required when enabled |
 | `reviewSkillPath` | `.claude/skills/review-all-prs/SKILL.md` | Review skill, relative to `emRepoPath` |
-| `reviewModel` | — | Model override for review runs |
+| `reviewModel` | — | Model override for review runs (independent of `model`) |
 | `reviewMaxTurns` | `200` | Max turns (review + verify is long-running) |
 | `reviewMaxDurationMs` | `3600000` (60 min) | Max review duration |
 | `reviewAllowedTools` | broad MCP + shell set | Tool surface for the review skill |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ For a single repo, set fields at the root level:
 | `logFormat` | `AI_AGENT_LOG_FORMAT` | `text` | `json` or `text` |
 | `logLevel` | `AI_AGENT_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
 
+### Variables the daemon SETS on its own sessions
+
+These are outputs, not config — the daemon exports them into every Claude session it spawns. Nothing reads them from your config, and setting them yourself has no effect on the daemon.
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `SLASHBIN_AGENT` | `foreman` | Marks the session as agent-driven rather than human-driven. |
+
+**Why it exists.** The review phase runs under the operator's GitHub token, so everything it does is attributed to that account. Without a marker, a `PreToolUse` hook cannot tell an agent's session from a human's — and every session is spawned with `--dangerously-skip-permissions`, so hooks are the only remaining control. On 2026-08-12 one cycle in our own deployment filed an issue, applied the trigger label to it, implemented, reviewed and merged it — a complete self-authorization loop in about fourteen minutes, recorded in the audit trail as the operator's work. The change happened to be correct; nothing structural had prevented it.
+
+**How to use it.** If you gate your trigger label with a hook, refuse the label when `SLASHBIN_AGENT` is set. The agent can still file issues — that is often the most valuable thing it does — but it cannot grant itself authorization to build them. If you do not run such a hook, the variable is simply present and unread; behaviour is unchanged.
+
 ### GitHub API budget
 
 Each poll cycle spends **one GraphQL request per repo** for issue discovery. GitHub's GraphQL limit is **5,000 requests/hour per token**, so the discovery floor is:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ The Foreman is one layer in an AI engineering pipeline:
 4. **Reviewers** (human or AI) provide feedback on PRs — Foreman revises automatically
 5. **Foreman** promotes merged work from develop → main via promotion PRs
 
-The Foreman uses a **dual-token model**: one GitHub token for its own operations (creating PRs, managing labels) and a second token for the Engineering Manager (approving and merging PRs that require branch protection). This satisfies branch protection, which requires the approving identity to differ from the PR author.
-
-> **The dual-token model is not, on its own, a guard against self-approval.** This paragraph used to claim it was. It is not: the review phase runs *under the EM token*, so anything it does there is both permitted and attributed to the EM. On 2026-08-12 one cycle in our own deployment used that token to file an issue, apply the trigger label to it, implement, review and merge it — a complete loop in about fourteen minutes, recorded as the operator's work. Two tokens separate *identities*; they do not separate *authority* when one process holds both. If self-approval matters to you, gate the trigger label on [`SLASHBIN_AGENT`](#variables-the-daemon-sets-on-its-own-sessions).
+The Foreman uses a **dual-token model**: one GitHub token for its own operations (creating PRs, managing labels) and a second token for the Engineering Manager (approving and merging PRs that require branch protection). This prevents the Foreman from self-approving its own work.
 
 This is the pattern behind [www.slashbin.io](https://www.slashbin.io?utm_source=github&utm_medium=readme&utm_campaign=ai-foreman_body) — structured context in, autonomous execution out. The Foreman doesn't need to understand your business. It reads the issue, reads the repo's CLAUDE.md, and invokes the skill.
 
@@ -222,7 +220,7 @@ Set these environment variables to enable status updates in Discord. The Foreman
 | Env Var | Description |
 |---|---|
 | `FOREMAN_GITHUB_TOKEN` | Token for Foreman operations (create PRs, manage labels) |
-| `EM_GITHUB_TOKEN` | Token for Engineering Manager operations (approve/merge PRs behind branch protection). **The review phase runs under this token**, so issues it files and labels it applies are attributed to the EM — see the note on self-approval above. |
+| `EM_GITHUB_TOKEN` | Token for Engineering Manager operations (approve/merge PRs behind branch protection) |
 
 ### Prompt template variables
 

--- a/README.md
+++ b/README.md
@@ -128,18 +128,6 @@ For a single repo, set fields at the root level:
 | `logFormat` | `AI_AGENT_LOG_FORMAT` | `text` | `json` or `text` |
 | `logLevel` | `AI_AGENT_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
 
-### Variables the daemon SETS on its own sessions
-
-These are outputs, not config — the daemon exports them into every Claude session it spawns. Nothing reads them from your config, and setting them yourself has no effect on the daemon.
-
-| Variable | Value | Purpose |
-|---|---|---|
-| `SLASHBIN_AGENT` | `foreman` | Marks the session as agent-driven rather than human-driven. |
-
-**Why it exists.** The review phase runs under the operator's GitHub token, so everything it does is attributed to that account. Without a marker, a `PreToolUse` hook cannot tell an agent's session from a human's — and every session is spawned with `--dangerously-skip-permissions`, so hooks are the only remaining control. On 2026-08-12 one cycle in our own deployment filed an issue, applied the trigger label to it, implemented, reviewed and merged it — a complete self-authorization loop in about fourteen minutes, recorded in the audit trail as the operator's work. The change happened to be correct; nothing structural had prevented it.
-
-**How to use it.** If you gate your trigger label with a hook, refuse the label when `SLASHBIN_AGENT` is set. The agent can still file issues — that is often the most valuable thing it does — but it cannot grant itself authorization to build them. If you do not run such a hook, the variable is simply present and unread; behaviour is unchanged.
-
 ### GitHub API budget
 
 Each poll cycle spends **one GraphQL request per repo** for issue discovery. GitHub's GraphQL limit is **5,000 requests/hour per token**, so the discovery floor is:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Reconciliation → Review → Revision → Implementation → Branch Sync → Pr
 ```
 
 1. **Reconcile** — detects orphaned commits on the features branch with no PR and creates one
-2. **Review** *(opt-in)* — when `reviewEnabled` is set, invokes a review skill on open feature PRs awaiting review. The review skill runs in a **separate review repo** (`emRepoPath`) under a separate GitHub token, and owns its own merge + label decisions; its label side effects (approve → ready-for-prod; request-changes → pending-actions) feed the Promote and Revise phases. Disabled by default — see [Review phase](#review-phase-opt-in)
+2. **Review** *(opt-in)* — when `reviewEnabled` is set, invokes a review skill on open feature PRs awaiting review. The review skill runs in a **separate review repo** (`emRepoPath`) under a separate GitHub token, and owns its own merge + label decisions; its label side effects (approve → `pr approved`; request-changes → `pr pending actions`) feed the Promote and Revise phases, and the Foreman reconciles the outcome label from the run's trailer if the skill merged without setting it. Disabled by default — see [Review phase](#review-phase-opt-in)
 3. **Revise** — finds PRs with pending review feedback and revises them (prioritized over new work)
 4. **Implement** — picks up approved issues and invokes the repo's implementation skill via Claude Code (up to 3 issues per cycle; 1 in greenfield repos)
 5. **Branch Sync** — merges main → develop to keep branches aligned after promotions
@@ -244,9 +244,61 @@ decision-layer workflow rather than an in-repo edit:
   behind `EM_GITHUB_TOKEN` (distinct from `FOREMAN_GITHUB_TOKEN`), keeping the
   reviewer identity separate from the implementer identity.
 - **Owns its own outcomes.** The skill posts the verdict, merges approved PRs, and
-  transitions issue labels itself — the Foreman does not relabel afterward. The label
-  side effects feed the other phases: approve → `ready for prod release` (Promote);
-  request-changes → `pr pending actions` (Revise).
+  transitions issue labels itself. The label side effects feed the other phases:
+  approve → `pr approved` (awaiting the human release gate); request-changes →
+  `pr pending actions` (Revise). The Foreman reconciles the label as a backstop
+  when the skill merged without setting it — see below.
+
+### Outcome-label reconciliation
+
+The merge is performed by code, but the *record* of what the merge meant used to be
+left entirely to the review agent to remember to write. When a session ended after
+merging but before labeling, the issue stayed at `pr under review` with its PR
+already closed — invisible to every phase, since the review gate only matches OPEN
+PRs. Measured over one week on a 20-repo fleet: **12 of 53 merges (~23%) stranded
+their issue this way.**
+
+The outcome was never actually unknown — it arrives in the `FOREMAN_REVIEW` trailer
+the Foreman already parses. `reviewLabelReconcile` (default `true`) spends it: after
+a run reports a merge, any linked issue still sitting at `pr under review` is moved
+to the label its own trailer implies.
+
+Four conditions gate every write, so the reconciler can only ever repair a missing
+write — never invent one, never overrule anyone:
+
+1. the issue is still at `pr under review` with no outcome label (a skill that
+   labels correctly never reaches this code, so a healthy pipeline is unchanged);
+2. a **merged** PR provably closed that issue, under the strict closing-keyword
+   predicate (a bare "related to #N" never counts);
+3. that PR emitted a trailer this run whose fields are unambiguous;
+4. the reviewer did not declare a hold (below).
+
+It never applies `ready for prod release`. That label authorizes production and
+remains a human act.
+
+Set `reviewLabelReconcile: false` (or `AI_AGENT_REVIEW_LABEL_RECONCILE=false`) to
+keep labeling strictly agent-owned.
+
+### Declaring a deliberate hold
+
+A reviewer that merges but *intentionally* leaves the label unset — typically an
+acceptance criterion that cannot be observed yet — appends an optional `hold=` field
+to that PR's trailer:
+
+```
+FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS hold=criterion-not-observable-until-0300z
+```
+
+The Foreman then neither sets the label nor re-verifies behind it, and surfaces the
+issue as *held* rather than failed. The hold is persisted in `.agent-state.json`, so
+it survives restarts, and clears automatically once the issue leaves the dead zone.
+
+Without this, a deliberate hold and a dropped label are the same observation, and
+automation has to guess — which means overwriting a correct judgment with a rubber
+stamp.
+
+The four-field trailer remains the contract: `hold=` is optional and trails the
+original fields, so trailers written before it existed parse identically.
 
 Every review run's full turn-by-turn interaction (`--output-format stream-json`) is
 written verbatim to `logs/review/<repo>-cycle<N>-<timestamp>.log` for debugging.
@@ -268,6 +320,7 @@ Review config keys (all optional; global, with a per-repo `reviewEnabled` overri
 | `reviewMaxDurationMs` | `3600000` (60 min) | Max review duration |
 | `reviewAllowedTools` | broad MCP + shell set | Tool surface for the review skill |
 | `reviewerLogin` | `slashbin-engineering-manager` | GitHub login the review runs as (freshness guard) |
+| `reviewLabelReconcile` | `true` | Set the outcome label from the run's own trailer when the skill merged without labeling. Env: `AI_AGENT_REVIEW_LABEL_RECONCILE` |
 
 Requires `EM_GITHUB_TOKEN` in the environment when enabled.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ For a single repo, set fields at the root level:
 | `githubRepo` | `AI_AGENT_GITHUB_REPO` | *(from git remote)* | GitHub `owner/repo` |
 | `triggerLabel` | `AI_AGENT_TRIGGER_LABEL` | `approved` | Label that triggers implementation |
 | `pollIntervalMs` | `AI_AGENT_POLL_INTERVAL_MS` | `300000` (5 min) | Poll interval in milliseconds |
+| `issueCacheTtlMs` | `AI_AGENT_ISSUE_CACHE_TTL_MS` | `30000` (30 s) | How long a repo's open-issue snapshot stays warm. Keep it **below** `pollIntervalMs`. `0` disables caching. See [GitHub API budget](#github-api-budget) |
+| `issueSnapshotLimit` | `AI_AGENT_ISSUE_SNAPSHOT_LIMIT` | `500` | Max open issues fetched per snapshot. Must exceed a repo's open-issue count; truncation is logged |
 | `skillPath` | `AI_AGENT_SKILL_PATH` | — | Claude Code skill for implementation |
 | `revisionSkillPath` | — | — | Claude Code skill for PR revision |
 | `prompt` | `AI_AGENT_PROMPT` | *(built-in)* | Custom prompt template |
@@ -125,6 +127,23 @@ For a single repo, set fields at the root level:
 | `allowedTools` | — | `["Read","Write","Edit","Bash","Glob","Grep"]` | Tools the CLI can use |
 | `logFormat` | `AI_AGENT_LOG_FORMAT` | `text` | `json` or `text` |
 | `logLevel` | `AI_AGENT_LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
+
+### GitHub API budget
+
+Each poll cycle spends **one GraphQL request per repo** for issue discovery. GitHub's GraphQL limit is **5,000 requests/hour per token**, so the discovery floor is:
+
+```
+repos × (3600000 / pollIntervalMs)   requests/hour
+```
+
+The daemon logs this as `estDiscoveryGraphQlPerHour` on startup — check it against 5,000 after adding repos or lowering the poll interval. 20 repos at a 60 s interval is 1,200/hour; the same 20 repos would need an interval under ~15 s before discovery alone threatened the ceiling. Merges, reviews, and promotions spend additional requests on top, but only when there is work.
+
+This budget is why the discovery phases share **one open-issue snapshot per repo per cycle** rather than issuing a query per label. Before that change, six lookups each ran their own `gh issue list` — 20 repos on a 60 s interval came to ~7,200 requests/hour, which permanently exhausted the token and made roughly one lookup in six fail. A failed lookup silently skips that phase for that repo that cycle, so `approved` issues sat unimplemented with nothing but generic errors in the log.
+
+Two consequences worth knowing:
+
+- **Keep `issueCacheTtlMs` below `pollIntervalMs`**, or a cycle can be served entirely from the previous cycle's snapshot and an externally-applied `approved` label waits an extra cycle. The daemon warns at startup if you cross that line.
+- **Rate-limit rejections are logged as `[gh] RATE LIMIT EXHAUSTED`** and are deliberately not retried — the budget is already spent. If you see them, raise `pollIntervalMs` or reduce the repo count.
 
 ### Multi-repo mode
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ The Foreman is one layer in an AI engineering pipeline:
 4. **Reviewers** (human or AI) provide feedback on PRs — Foreman revises automatically
 5. **Foreman** promotes merged work from develop → main via promotion PRs
 
-The Foreman uses a **dual-token model**: one GitHub token for its own operations (creating PRs, managing labels) and a second token for the Engineering Manager (approving and merging PRs that require branch protection). This prevents the Foreman from self-approving its own work.
+The Foreman uses a **dual-token model**: one GitHub token for its own operations (creating PRs, managing labels) and a second token for the Engineering Manager (approving and merging PRs that require branch protection). This satisfies branch protection, which requires the approving identity to differ from the PR author.
+
+> **The dual-token model is not, on its own, a guard against self-approval.** This paragraph used to claim it was. It is not: the review phase runs *under the EM token*, so anything it does there is both permitted and attributed to the EM. On 2026-08-12 one cycle in our own deployment used that token to file an issue, apply the trigger label to it, implement, review and merge it — a complete loop in about fourteen minutes, recorded as the operator's work. Two tokens separate *identities*; they do not separate *authority* when one process holds both. If self-approval matters to you, gate the trigger label on [`SLASHBIN_AGENT`](#variables-the-daemon-sets-on-its-own-sessions).
 
 This is the pattern behind [www.slashbin.io](https://www.slashbin.io?utm_source=github&utm_medium=readme&utm_campaign=ai-foreman_body) — structured context in, autonomous execution out. The Foreman doesn't need to understand your business. It reads the issue, reads the repo's CLAUDE.md, and invokes the skill.
 
@@ -220,7 +222,7 @@ Set these environment variables to enable status updates in Discord. The Foreman
 | Env Var | Description |
 |---|---|
 | `FOREMAN_GITHUB_TOKEN` | Token for Foreman operations (create PRs, manage labels) |
-| `EM_GITHUB_TOKEN` | Token for Engineering Manager operations (approve/merge PRs behind branch protection) |
+| `EM_GITHUB_TOKEN` | Token for Engineering Manager operations (approve/merge PRs behind branch protection). **The review phase runs under this token**, so issues it files and labels it applies are attributed to the EM — see the note on self-approval above. |
 
 ### Prompt template variables
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ The Foreman shines when you have **more approved work than time to implement**. 
 
 ## What the Foreman does
 
-Each poll cycle runs five phases across every configured repo:
+Each poll cycle runs six phases across every configured repo:
 
 ```
-Reconciliation → Revision → Implementation → Branch Sync → Promotion
+Reconciliation → Review → Revision → Implementation → Branch Sync → Promotion
 ```
 
 1. **Reconcile** — detects orphaned commits on the features branch with no PR and creates one
-2. **Revise** — finds PRs with pending review feedback and revises them (prioritized over new work)
-3. **Implement** — picks up approved issues and invokes the repo's implementation skill via Claude Code (up to 3 issues per cycle; 1 in greenfield repos)
-4. **Branch Sync** — merges main → develop to keep branches aligned after promotions
-5. **Promote** — creates promotion PRs (develop → main) for issues labeled `ready for prod release`
+2. **Review** *(opt-in)* — when `reviewEnabled` is set, invokes a review skill on open feature PRs awaiting review. The review skill runs in a **separate review repo** (`emRepoPath`) under a separate GitHub token, and owns its own merge + label decisions; its label side effects (approve → ready-for-prod; request-changes → pending-actions) feed the Promote and Revise phases. Disabled by default — see [Review phase](#review-phase-opt-in)
+3. **Revise** — finds PRs with pending review feedback and revises them (prioritized over new work)
+4. **Implement** — picks up approved issues and invokes the repo's implementation skill via Claude Code (up to 3 issues per cycle; 1 in greenfield repos)
+5. **Branch Sync** — merges main → develop to keep branches aligned after promotions
+6. **Promote** — creates promotion PRs (develop → main) for issues labeled `ready for prod release`
 
 - **Poll interval is configurable** — default 5 minutes (`pollIntervalMs` in config)
 - **Multi-repo** — manages multiple repos in a single daemon, each with its own skill paths and config
@@ -207,6 +208,50 @@ The Foreman delegates work by invoking Claude Code skills on each service repo. 
 
 The Foreman passes the issue context to Claude and instructs it to read and follow the skill. The skill defines the repo-specific implementation workflow — how to branch, test, and structure the PR.
 
+## Review phase (opt-in)
+
+The Review phase closes the loop between Implementation and Revision by invoking a
+**review skill** on open feature PRs awaiting review — automating the human/agent
+reviewer step. It is **disabled by default** (`reviewEnabled: false`); a vanilla
+config keeps the original five-phase behavior unchanged.
+
+It differs from Implementation/Revision in three ways, because review is a
+decision-layer workflow rather than an in-repo edit:
+
+- **Runs in a separate review repo.** The review skill is invoked with its working
+  directory set to `emRepoPath`, not the service repo — so it has the reviewer's own
+  tooling (MCP servers, verification scripts, context docs) available.
+- **Runs under a separate token.** Reviews and merges are attributed to the account
+  behind `EM_GITHUB_TOKEN` (distinct from `FOREMAN_GITHUB_TOKEN`), keeping the
+  reviewer identity separate from the implementer identity.
+- **Owns its own outcomes.** The skill posts the verdict, merges approved PRs, and
+  transitions issue labels itself — the Foreman does not relabel afterward. The label
+  side effects feed the other phases: approve → `ready for prod release` (Promote);
+  request-changes → `pr pending actions` (Revise).
+
+Every review run's full turn-by-turn interaction (`--output-format stream-json`) is
+written verbatim to `logs/review/<repo>-cycle<N>-<timestamp>.log` for debugging.
+
+A PR is gated into review only when its linked issue is labeled `pr under review`,
+it has an open `featureBranch → baseBranch` PR, and there is no review by
+`reviewerLogin` newer than the PR's latest commit (a freshness guard against
+re-review loops).
+
+Review config keys (all optional; global, with a per-repo `reviewEnabled` override):
+
+| Key | Default | Description |
+|---|---|---|
+| `reviewEnabled` | `false` | Enable the Review phase (per-repo override supported) |
+| `emRepoPath` | — | Working dir for the review skill (the review repo). Required when enabled |
+| `reviewSkillPath` | `.claude/skills/review-all-prs/SKILL.md` | Review skill, relative to `emRepoPath` |
+| `reviewModel` | — | Model override for review runs |
+| `reviewMaxTurns` | `200` | Max turns (review + verify is long-running) |
+| `reviewMaxDurationMs` | `3600000` (60 min) | Max review duration |
+| `reviewAllowedTools` | broad MCP + shell set | Tool surface for the review skill |
+| `reviewerLogin` | `slashbin-engineering-manager` | GitHub login the review runs as (freshness guard) |
+
+Requires `EM_GITHUB_TOKEN` in the environment when enabled.
+
 ## Image handling in issue bodies
 
 Claude is multimodal — when an issue body or PR review comment contains markdown image references like `![alt](https://...)`, those images are part of the spec (mockups, screenshots, walkthrough frames). The Foreman appends instructions to its default and skill-driven prompts telling the agent to fetch each image to a temp file and `Read` it, so the model can see image content.
@@ -238,7 +283,7 @@ src/
 ├── github.ts          # GitHub API (polling, PRs, labels, dual-token ops)
 ├── agent.ts           # Claude Code CLI spawner
 ├── reviewer.ts        # PR review feedback handler
-├── orchestrator.ts    # 5-phase cycle, failure cooldowns, state tracking
+├── orchestrator.ts    # 6-phase cycle, failure cooldowns, state tracking
 ├── state.ts           # Persistent state management
 ├── daemon.ts          # Poll loop, graceful shutdown, Discord bridge
 ├── bridge-client.ts   # WebSocket client for Discord notifications

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "logs:repo": "node agent-manager.mjs logs --repo",
     "start:fg": "node dist/cli.js",
     "once": "node dist/cli.js --once",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test test/*.test.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -66,6 +66,19 @@ export interface ReviewTrailer {
   verdict: string;
   merged: boolean;
   deploy: string;
+  /**
+   * Reason the reviewer DELIBERATELY withheld the issue's outcome label, from the
+   * optional `hold=` field. Undefined when the field is absent (every trailer
+   * written before this field existed) or when it says no/none/false.
+   *
+   * This exists to keep one honest case from being punished by the label
+   * reconciler: a reviewer that cannot yet judge an acceptance criterion (e.g. one
+   * that only becomes observable at a later time boundary) is RIGHT to leave the
+   * label alone, and must be able to say so. Without a way to declare it, a
+   * deliberate hold and a dropped label are the same observation, and automation
+   * has to guess — which means overwriting a correct judgment with a rubber stamp.
+   */
+  hold?: string;
 }
 
 export interface ReviewResult {
@@ -87,22 +100,27 @@ export interface ReviewResult {
  * acted on:
  *   FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS
  */
-function parseReviewTrailerRecords(stdout: string): ReviewTrailer[] {
+export function parseReviewTrailerRecords(stdout: string): ReviewTrailer[] {
   // Each field uses a bounded token alphabet ([\w/-]+) so it cannot bleed into
   // surrounding characters when the trailer is emitted inside a single-line
   // stream-JSON envelope (the Claude CLI's --output-format=stream-json), where
   // the characters immediately after the trailer (`"}],"STOP_REASON":NULL,…`)
   // are non-whitespace and would be greedily absorbed by an unbounded `\S+`.
-  const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=([\w/-]+)\s+merged=([\w/-]+)\s+deploy=([\w/-]+)/gi;
+  // `hold=` is OPTIONAL and trails the original four fields, so every trailer
+  // written before it existed still matches with the group undefined. Do not
+  // reorder or make it required — the four-field form is the published contract.
+  const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=([\w/-]+)\s+merged=([\w/-]+)\s+deploy=([\w/-]+)(?:\s+hold=([\w/-]+))?/gi;
   const out: ReviewTrailer[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(stdout)) !== null) {
-    const [, pr, verdict, merged, deploy] = m;
+    const [, pr, verdict, merged, deploy, hold] = m;
+    const holding = hold !== undefined && !/^(0|n|no|none|false|off)$/i.test(hold);
     out.push({
       pr: Number(pr),
       verdict: verdict.toUpperCase(),
       merged: /^(y|yes|true)$/i.test(merged),
       deploy: deploy.toUpperCase(),
+      ...(holding ? { hold } : {}),
     });
   }
   return out;
@@ -115,7 +133,8 @@ function formatReviewTrailers(trailers: ReviewTrailer[]): string | undefined {
     .map((t) => {
       const mergedTxt = t.merged ? "merged" : "not merged";
       const deployTxt = /^(NA|N\/A|NONE)$/.test(t.deploy) ? "no deploy" : `deploy ${t.deploy}`;
-      return `#${t.pr} ${t.verdict} · ${mergedTxt} · ${deployTxt}`;
+      const holdTxt = t.hold ? ` · HELD (${t.hold})` : "";
+      return `#${t.pr} ${t.verdict} · ${mergedTxt} · ${deployTxt}${holdTxt}`;
     })
     .join("; ");
 }
@@ -650,11 +669,15 @@ Work autonomously. Do not ask questions.`;
  *   - the broad reviewAllowedTools surface (GitHub/Postgres/Redis/Railway MCP)
  *
  * Full-fidelity: the skill posts verdicts, merges approved PRs to develop, verifies
- * dev, files S3/S4 follow-ups, and updates labels itself. The orchestrator does NOT
- * relabel after a review run — unlike implement/revise, the skill owns its own label
- * transitions. The review's label side effects feed the existing phases: APPROVE →
- * `pr approved` (awaiting the EM outcome-gate); REQUEST_CHANGES → `pr pending actions`
- * (revise phase).
+ * dev, files S3/S4 follow-ups, and updates labels itself. The review's label side
+ * effects feed the existing phases: APPROVE → `pr approved` (awaiting the EM
+ * outcome-gate); REQUEST_CHANGES → `pr pending actions` (revise phase).
+ *
+ * The skill remains the PRIMARY labeler — it does things the orchestrator cannot
+ * (post the review body, file the follow-ups that belong with the verdict). But it
+ * is no longer the ONLY one: the orchestrator reconciles the outcome label from the
+ * returned trailers when the skill merged without labeling. See
+ * `reconcileReviewOutcomeLabels` in orchestrator.ts for why the write moved.
  */
 export async function reviewOpenPRs(
   repoConfig: RepoConfig,
@@ -682,7 +705,7 @@ Follow the skill exactly and act autonomously — do NOT ask questions or wait f
 - Review each open \`features → develop\` PR (skill Phase 3): the Fix-Completeness gate first, then the rubric.
 - For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`pr approved\` per the skill. Do NOT apply \`ready for prod release\` — that label is the EM outcome-gate's signature (separation of duties; see /review-pr Step 17).
 - For BLOCKED PRs: post REQUEST_CHANGES, label the linked issue \`pr pending actions\`, and file S3/S4 follow-up issues per the skill.
-- Update issue labels yourself exactly as the skill specifies — the orchestrator will NOT relabel after you.
+- Update issue labels yourself exactly as the skill specifies. The orchestrator reconciles the outcome label from your trailer only when you left it unset — it never overrides a label you did set.
 
 CRITICAL — THIS IS A HEADLESS SESSION. THERE IS NO NEXT TURN.
 Ending your turn ends the process. Anything still running is killed at that instant, and everything you had not done yet never happens.
@@ -699,6 +722,14 @@ IMPORTANT — status trailer: After you finish, end your output with one line pe
 FOREMAN_REVIEW pr=#<number> verdict=<APPROVE|REQUEST_CHANGES> merged=<yes|no> deploy=<SUCCESS|FAILURE|NA>
 
 Rules for the trailer: \`merged=yes\` only if you actually merged the PR to the base branch. \`deploy=SUCCESS\`/\`deploy=FAILURE\` reflects the post-merge deployment+verification result for that merge (use \`deploy=NA\` when nothing was merged, or when the repo has no deployment to verify, e.g. a docs/CLI/npm-package repo). Emit one trailer line for every PR you reviewed this run.
+
+OPTIONAL — deliberate hold: if you merged a PR but are INTENTIONALLY leaving the issue at \`pr under review\` (e.g. an acceptance criterion cannot be observed yet), append \`hold=<short-reason-slug>\` to that PR's trailer line:
+
+FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS hold=criterion-not-observable-until-0300z
+
+Use it ONLY for a decision you actually made. It tells the Foreman the label is missing ON PURPOSE, so it will neither auto-set the label nor auto-re-verify behind you — the issue stays visible as a held item instead of being reported as a failure. Omit the field entirely for the normal case; omitting it means "I finished the labeling."
+
+Note: the Foreman now reconciles the outcome label from this trailer as a BACKSTOP — if you merged and did not label, it applies the label your trailer implies. That is a safety net, not a substitute: still set the labels yourself per the skill, because only you can file the follow-ups and post the review body that go with them.
 
 The trailer is MANDATORY and is the last thing you emit. A run that ends without either a \`FOREMAN_REVIEW pr=…\` line or \`FOREMAN_REVIEW none\` is recorded as a FAILED review regardless of how much work you did, because from the outside it is indistinguishable from a session that died mid-merge.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -15,6 +15,29 @@ export interface ReviewResult {
   error?: string;
   // The skill's final summary text (parsed from the stream-json result event).
   summary?: string;
+  // Concise per-PR status parsed from the FOREMAN_REVIEW trailer(s), including the
+  // deployment outcome — e.g. "#100 APPROVE · merged · deploy SUCCESS". Surfaced
+  // in the Foreman's Discord status line. Undefined if no trailer was emitted.
+  statusLine?: string;
+}
+
+/**
+ * Parse the structured review trailers the skill is asked to emit, one per PR it
+ * acted on:
+ *   FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS
+ * Returns a concise human-readable line, or undefined when no trailer is present.
+ */
+function parseReviewTrailers(stdout: string): string | undefined {
+  const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=(\S+)\s+merged=(\S+)\s+deploy=(\S+)/gi;
+  const parts: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stdout)) !== null) {
+    const [, pr, verdict, merged, deploy] = m;
+    const mergedTxt = /^y(es)?|true$/i.test(merged) ? "merged" : "not merged";
+    const deployTxt = /^(na|n\/a|none)$/i.test(deploy) ? "no deploy" : `deploy ${deploy.toUpperCase()}`;
+    parts.push(`#${pr} ${verdict.toUpperCase()} · ${mergedTxt} · ${deployTxt}`);
+  }
+  return parts.length > 0 ? parts.join("; ") : undefined;
 }
 
 export interface ImplementationResult {
@@ -573,6 +596,12 @@ Follow the skill exactly and act autonomously — do NOT ask questions or wait f
 
 If there are no open feature PRs awaiting review for this repo, that is a clean no-op — say so and stop.
 
+IMPORTANT — status trailer: After you finish, end your output with one line per PR you acted on, in EXACTLY this format (nothing after the last one):
+
+FOREMAN_REVIEW pr=#<number> verdict=<APPROVE|REQUEST_CHANGES> merged=<yes|no> deploy=<SUCCESS|FAILURE|NA>
+
+Rules for the trailer: \`merged=yes\` only if you actually merged the PR to the base branch. \`deploy=SUCCESS\`/\`deploy=FAILURE\` reflects the post-merge deployment+verification result for that merge (use \`deploy=NA\` when nothing was merged, or when the repo has no deployment to verify, e.g. a docs/CLI/npm-package repo). Emit one trailer line for every PR you reviewed this run.
+
 ${IMAGE_HANDLING_INSTRUCTIONS}`;
 
   const result = await spawnClaudeWithOptions(
@@ -604,10 +633,14 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
   }
 
   const summary = extractStreamResult(result.stdout);
+  const statusLine = parseReviewTrailers(result.stdout);
   if (summary) {
     logger.info(`Review completed for ${repoConfig.name}:\n${summary}`);
   } else {
     logger.info(`Review completed for ${repoConfig.name} (no parseable summary; see transcript${transcriptPath ? ` ${transcriptPath}` : ""})`);
   }
-  return { success: true, summary };
+  if (statusLine) {
+    logger.info(`Review outcome for ${repoConfig.name}: ${statusLine}`);
+  }
+  return { success: true, summary, statusLine };
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -295,6 +295,24 @@ function spawnClaudeWithOptions(
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
   if (opts.ghToken) env.GH_TOKEN = opts.ghToken;
 
+  /**
+   * Mark every session this daemon starts as agent-driven.
+   *
+   * The review phase runs in the EM repo under the EM token, so anything it does
+   * on GitHub is attributed to the EM. On 2026-08-12 that let one cycle file an
+   * issue, apply `approved` to it, implement it, review it and merge it — a
+   * complete self-authorization loop that the audit trail recorded as the EM's
+   * work. The change was correct; nothing structural had prevented it.
+   *
+   * `approved` is a flight authorization, and an agent must not grant itself
+   * one. Hooks are the only control left here because every session is spawned
+   * with --dangerously-skip-permissions, and a hook cannot tell whose session it
+   * is running in unless the environment says so. This is that signal. It is
+   * purely additive: a fork that does not run those hooks simply carries an
+   * unread variable. Documented in README.md.
+   */
+  env.SLASHBIN_AGENT = "foreman";
+
   return new Promise<SpawnResult>((resolve) => {
     let stdout = "";
     let stderr = "";

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -568,7 +568,7 @@ Work autonomously. Do not ask questions.`;
  * dev, files S3/S4 follow-ups, and updates labels itself. The orchestrator does NOT
  * relabel after a review run — unlike implement/revise, the skill owns its own label
  * transitions. The review's label side effects feed the existing phases: APPROVE →
- * `ready for prod release` (promote phase); REQUEST_CHANGES → `pr pending actions`
+ * `pr approved` (awaiting the EM outcome-gate); REQUEST_CHANGES → `pr pending actions`
  * (revise phase).
  */
 export async function reviewOpenPRs(
@@ -595,7 +595,7 @@ Review the open feature PRs for the repository \`${repoConfig.githubRepo}\` ONLY
 Follow the skill exactly and act autonomously — do NOT ask questions or wait for confirmation:
 - Run the relevant healthchecks first (skill Phase 0).
 - Review each open \`features → develop\` PR (skill Phase 3): the Fix-Completeness gate first, then the rubric.
-- For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`ready for prod release\` per the skill.
+- For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`pr approved\` per the skill. Do NOT apply \`ready for prod release\` — that label is the EM outcome-gate's signature (separation of duties; see /review-pr Step 17).
 - For BLOCKED PRs: post REQUEST_CHANGES, label the linked issue \`pr pending actions\`, and file S3/S4 follow-up issues per the skill.
 - Update issue labels yourself exactly as the skill specifies — the orchestrator will NOT relabel after you.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,11 +1,20 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import type { RepoConfig } from "./config.js";
+import { mkdirSync, createWriteStream, type WriteStream } from "node:fs";
+import { dirname } from "node:path";
+import type { AgentConfig, RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import { verifyPRExists, checkPRHasChanges, getRemoteBranchSha } from "./github.js";
 
 export interface RevisionResult {
   success: boolean;
   error?: string;
+}
+
+export interface ReviewResult {
+  success: boolean;
+  error?: string;
+  // The skill's final summary text (parsed from the stream-json result event).
+  summary?: string;
 }
 
 export interface ImplementationResult {
@@ -81,26 +90,80 @@ const IMAGE_HANDLING_INSTRUCTIONS = `IMAGE HANDLING: If an issue body or PR revi
 
 The Authorization header is required for private-repo URLs (github.com/.../raw/...) and harmless for public CDN URLs (github.com/user-attachments/...). If a fetch fails, log a warning and proceed with the text spec — do not abort the implementation.`;
 
-function spawnClaude(
+interface SpawnOptions {
+  /** Working directory for the claude process. */
+  cwd: string;
+  /** Value to inject as GH_TOKEN (controls GitHub account attribution). */
+  ghToken?: string;
+  model?: string;
+  allowedTools: string[];
+  maxTurns: number;
+  maxDurationMs: number;
+  /**
+   * Emit the full turn-by-turn interaction as newline-delimited JSON
+   * (`--output-format stream-json --verbose`) instead of just the final text.
+   * Used by the review phase so the transcript captures every tool call + result.
+   */
+  streamJson?: boolean;
+  /**
+   * When set, the raw stdout/stderr stream is appended to this file verbatim for
+   * post-hoc debugging. The directory is created if needed.
+   */
+  transcriptPath?: string;
+}
+
+/**
+ * Low-level Claude CLI spawn. All callers go through this so the timeout/abort/
+ * stream-capture behavior is shared. The per-call options carry cwd, token, and
+ * tool surface — implement/revise run in the service repo under the Foreman
+ * token; review runs in the EM repo under the EM token (see reviewOpenPRs).
+ */
+function spawnClaudeWithOptions(
   prompt: string,
-  config: RepoConfig,
+  opts: SpawnOptions,
   logger: Logger,
   abortSignal?: AbortSignal
 ): Promise<SpawnResult> {
   const args = [
     "--print",
     prompt,
-    "--max-turns", String(config.maxTurns),
+    "--max-turns", String(opts.maxTurns),
     "--dangerously-skip-permissions",
   ];
 
-  if (config.model) {
-    args.push("--model", config.model);
+  if (opts.streamJson) {
+    args.push("--output-format", "stream-json", "--verbose");
   }
 
-  if (config.allowedTools.length > 0) {
-    args.push("--allowedTools", config.allowedTools.join(","));
+  if (opts.model) {
+    args.push("--model", opts.model);
   }
+
+  if (opts.allowedTools.length > 0) {
+    args.push("--allowedTools", opts.allowedTools.join(","));
+  }
+
+  let transcript: WriteStream | null = null;
+  if (opts.transcriptPath) {
+    try {
+      mkdirSync(dirname(opts.transcriptPath), { recursive: true });
+      transcript = createWriteStream(opts.transcriptPath, { flags: "a" });
+      const argsForLog = args.map((a) => (a === prompt ? "<prompt>" : a));
+      transcript.write(
+        `# claude invocation @ ${new Date().toISOString()}\n` +
+        `# cwd=${opts.cwd}\n` +
+        `# args=${JSON.stringify(argsForLog)}\n` +
+        `# prompt:\n${prompt}\n\n===== STREAM =====\n`
+      );
+    } catch (err) {
+      logger.warn(`Failed to open transcript ${opts.transcriptPath}: ${err instanceof Error ? err.message : String(err)}`);
+      transcript = null;
+    }
+  }
+
+  // GH_TOKEN must be a string or absent — never literal "undefined".
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (opts.ghToken) env.GH_TOKEN = opts.ghToken;
 
   return new Promise<SpawnResult>((resolve) => {
     let stdout = "";
@@ -108,16 +171,25 @@ function spawnClaude(
     let child: ChildProcess | null = null;
     let timedOut = false;
 
+    const finish = (r: SpawnResult) => {
+      if (transcript) {
+        transcript.write(`\n===== END (exit=${r.exitCode}${r.timedOut ? ", timedOut" : ""}) @ ${new Date().toISOString()} =====\n`);
+        transcript.end();
+        transcript = null;
+      }
+      resolve(r);
+    };
+
     const timeout = setTimeout(() => {
       timedOut = true;
-      logger.warn(`Claude CLI timed out after ${config.maxDurationMs}ms`);
+      logger.warn(`Claude CLI timed out after ${opts.maxDurationMs}ms`);
       if (child) {
         child.kill("SIGTERM");
         setTimeout(() => {
           if (child && !child.killed) child.kill("SIGKILL");
         }, 10_000);
       }
-    }, config.maxDurationMs);
+    }, opts.maxDurationMs);
 
     const onAbort = () => {
       logger.warn("Claude CLI aborted");
@@ -128,18 +200,21 @@ function spawnClaude(
     }
 
     child = spawn("claude", args, {
-      cwd: config.repoPath,
-      env: { ...process.env, GH_TOKEN: process.env.FOREMAN_GITHUB_TOKEN } as Record<string, string>,
+      cwd: opts.cwd,
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
     child.stdout?.on("data", (data: Buffer) => {
       stdout += data.toString();
+      transcript?.write(data);
     });
 
     child.stderr?.on("data", (data: Buffer) => {
-      stderr += data.toString();
-      const lines = data.toString().split("\n").filter(Boolean);
+      const text = data.toString();
+      stderr += text;
+      transcript?.write(`[stderr] ${text}`);
+      const lines = text.split("\n").filter(Boolean);
       for (const line of lines) {
         logger.warn(`[claude stderr] ${line}`);
       }
@@ -148,16 +223,61 @@ function spawnClaude(
     child.on("error", (err) => {
       clearTimeout(timeout);
       if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
-      resolve({ stdout, stderr: err.message, exitCode: -1, timedOut: false });
+      finish({ stdout, stderr: err.message, exitCode: -1, timedOut: false });
     });
 
     child.on("close", (code) => {
       clearTimeout(timeout);
       if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
       child = null;
-      resolve({ stdout, stderr, exitCode: code, timedOut });
+      finish({ stdout, stderr, exitCode: code, timedOut });
     });
   });
+}
+
+/**
+ * Backward-compatible spawn for implement/revise: runs in the service repo under
+ * the Foreman token with the narrow tool set, final-text output, no transcript.
+ */
+function spawnClaude(
+  prompt: string,
+  config: RepoConfig,
+  logger: Logger,
+  abortSignal?: AbortSignal
+): Promise<SpawnResult> {
+  return spawnClaudeWithOptions(
+    prompt,
+    {
+      cwd: config.repoPath,
+      ghToken: process.env.FOREMAN_GITHUB_TOKEN,
+      model: config.model,
+      allowedTools: config.allowedTools,
+      maxTurns: config.maxTurns,
+      maxDurationMs: config.maxDurationMs,
+    },
+    logger,
+    abortSignal
+  );
+}
+
+/**
+ * Parse the final `result` event from a stream-json transcript and return its
+ * text (truncated). Falls back to undefined when no result event is present.
+ */
+function extractStreamResult(stdout: string): string | undefined {
+  const lines = stdout.split("\n").filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const evt = JSON.parse(lines[i]);
+      if (evt && evt.type === "result") {
+        const text = typeof evt.result === "string" ? evt.result : JSON.stringify(evt);
+        return text.slice(0, 2000);
+      }
+    } catch {
+      // not a JSON line — keep scanning
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -400,4 +520,94 @@ Work autonomously. Do not ask questions.`;
 
   logger.info(`PR revision completed successfully for ${config.name}`);
   return { success: true };
+}
+
+/**
+ * Invoke the EM repo's /review-all-prs skill, scoped to a single service repo,
+ * in a headless Claude session.
+ *
+ * This is categorically different from implement/revise: those run IN the service
+ * repo under the Foreman token with a narrow tool set. Review is a decision-layer
+ * workflow — it needs the EM repo's MCP servers, npm scripts (healthcheck/verify/
+ * validate), and context/docs — so it runs with:
+ *   - cwd  = the EM repo (agentConfig.emRepoPath), so it loads the EM .mcp.json,
+ *            .claude/skills, and context/docs
+ *   - token = EM_GITHUB_TOKEN, so reviews/merges are attributed to the EM account
+ *             (memory: feedback_mcp_github_for_review_actions)
+ *   - the broad reviewAllowedTools surface (GitHub/Postgres/Redis/Railway MCP)
+ *
+ * Full-fidelity: the skill posts verdicts, merges approved PRs to develop, verifies
+ * dev, files S3/S4 follow-ups, and updates labels itself. The orchestrator does NOT
+ * relabel after a review run — unlike implement/revise, the skill owns its own label
+ * transitions. The review's label side effects feed the existing phases: APPROVE →
+ * `ready for prod release` (promote phase); REQUEST_CHANGES → `pr pending actions`
+ * (revise phase).
+ */
+export async function reviewOpenPRs(
+  repoConfig: RepoConfig,
+  agentConfig: AgentConfig,
+  logger: Logger,
+  abortSignal?: AbortSignal,
+  transcriptPath?: string,
+): Promise<ReviewResult> {
+  const emToken = process.env.EM_GITHUB_TOKEN;
+  if (!emToken) {
+    return { success: false, error: "EM_GITHUB_TOKEN not set — refusing to run review without EM-account attribution" };
+  }
+  if (!agentConfig.emRepoPath) {
+    return { success: false, error: "emRepoPath not configured — cannot locate the review skill" };
+  }
+
+  logger.info(`Starting review for ${repoConfig.name} (${repoConfig.githubRepo}) — cwd=${agentConfig.emRepoPath}`);
+
+  const prompt = `Read and follow the skill at ${agentConfig.reviewSkillPath}.
+
+Review the open feature PRs for the repository \`${repoConfig.githubRepo}\` ONLY. Treat this as the skill's repo-scoped mode (equivalent to \`--repo ${repoConfig.githubRepo}\`): scope every step — inventory, review, merge, verify — to that single repository, and use the full \`owner/repo\` slug \`${repoConfig.githubRepo}\` for all GitHub operations (do not rely on a short repo alias).
+
+Follow the skill exactly and act autonomously — do NOT ask questions or wait for confirmation:
+- Run the relevant healthchecks first (skill Phase 0).
+- Review each open \`features → develop\` PR (skill Phase 3): the Fix-Completeness gate first, then the rubric.
+- For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`ready for prod release\` per the skill.
+- For BLOCKED PRs: post REQUEST_CHANGES, label the linked issue \`pr pending actions\`, and file S3/S4 follow-up issues per the skill.
+- Update issue labels yourself exactly as the skill specifies — the orchestrator will NOT relabel after you.
+
+If there are no open feature PRs awaiting review for this repo, that is a clean no-op — say so and stop.
+
+${IMAGE_HANDLING_INSTRUCTIONS}`;
+
+  const result = await spawnClaudeWithOptions(
+    prompt,
+    {
+      cwd: agentConfig.emRepoPath,
+      ghToken: emToken,
+      model: agentConfig.reviewModel,
+      allowedTools: agentConfig.reviewAllowedTools,
+      maxTurns: agentConfig.reviewMaxTurns,
+      maxDurationMs: agentConfig.reviewMaxDurationMs,
+      streamJson: true,
+      transcriptPath,
+    },
+    logger,
+    abortSignal
+  );
+
+  if (result.timedOut) {
+    return { success: false, error: "timed out" };
+  }
+
+  if (result.exitCode !== 0) {
+    const stderrMsg = result.stderr.trim();
+    const stdoutTail = result.stdout.trim().slice(-500);
+    const error = stderrMsg || stdoutTail || `exit code ${result.exitCode}`;
+    logger.error(`Review Claude CLI exited with code ${result.exitCode}: ${error}`);
+    return { success: false, error };
+  }
+
+  const summary = extractStreamResult(result.stdout);
+  if (summary) {
+    logger.info(`Review completed for ${repoConfig.name}:\n${summary}`);
+  } else {
+    logger.info(`Review completed for ${repoConfig.name} (no parseable summary; see transcript${transcriptPath ? ` ${transcriptPath}` : ""})`);
+  }
+  return { success: true, summary };
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -703,7 +703,7 @@ Review the open feature PRs for the repository \`${repoConfig.githubRepo}\` ONLY
 Follow the skill exactly and act autonomously — do NOT ask questions or wait for confirmation:
 - Run the relevant healthchecks first (skill Phase 0).
 - Review each open \`features → develop\` PR (skill Phase 3): the Fix-Completeness gate first, then the rubric.
-- For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`pr approved\` per the skill. Do NOT apply \`ready for prod release\` — that label is the EM outcome-gate's signature (separation of duties; see /review-pr Step 17).
+- For APPROVED PRs: post the review from the EM account, merge to develop, then verify dev and label \`pr approved\` per the skill. Do NOT apply \`ready for prod release\`, and do NOT remove it either — that label is the EM outcome-gate's signature (separation of duties; see /review-pr Step 17). If a linked issue already carries it, the EM has signed off ahead of you: leave that issue's labels alone entirely. Removing it silently blocks the promotion PR forever, so the Foreman now detects and restores it — but a restore is a repaired mistake, not a supported path.
 - For BLOCKED PRs: post REQUEST_CHANGES, label the linked issue \`pr pending actions\`, and file S3/S4 follow-up issues per the skill.
 - Update issue labels yourself exactly as the skill specifies. The orchestrator reconciles the outcome label from your trailer only when you left it unset — it never overrides a label you did set.
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -295,24 +295,6 @@ function spawnClaudeWithOptions(
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
   if (opts.ghToken) env.GH_TOKEN = opts.ghToken;
 
-  /**
-   * Mark every session this daemon starts as agent-driven.
-   *
-   * The review phase runs in the EM repo under the EM token, so anything it does
-   * on GitHub is attributed to the EM. On 2026-08-12 that let one cycle file an
-   * issue, apply `approved` to it, implement it, review it and merge it — a
-   * complete self-authorization loop that the audit trail recorded as the EM's
-   * work. The change was correct; nothing structural had prevented it.
-   *
-   * `approved` is a flight authorization, and an agent must not grant itself
-   * one. Hooks are the only control left here because every session is spawned
-   * with --dangerously-skip-permissions, and a hook cannot tell whose session it
-   * is running in unless the environment says so. This is that signal. It is
-   * purely additive: a fork that does not run those hooks simply carries an
-   * unread variable. Documented in README.md.
-   */
-  env.SLASHBIN_AGENT = "foreman";
-
   return new Promise<SpawnResult>((resolve) => {
     let stdout = "";
     let stderr = "";

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -28,7 +28,12 @@ export interface ReviewResult {
  * Returns a concise human-readable line, or undefined when no trailer is present.
  */
 function parseReviewTrailers(stdout: string): string | undefined {
-  const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=(\S+)\s+merged=(\S+)\s+deploy=(\S+)/gi;
+  // Each field uses a bounded token alphabet ([\w/-]+) so it cannot bleed into
+  // surrounding characters when the trailer is emitted inside a single-line
+  // stream-JSON envelope (the Claude CLI's --output-format=stream-json), where
+  // the characters immediately after the trailer (`"}],"STOP_REASON":NULL,…`)
+  // are non-whitespace and would be greedily absorbed by an unbounded `\S+`.
+  const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=([\w/-]+)\s+merged=([\w/-]+)\s+deploy=([\w/-]+)/gi;
   const parts: string[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(stdout)) !== null) {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,9 +1,59 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { mkdirSync, createWriteStream, type WriteStream } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type { AgentConfig, RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import { verifyPRExists, checkPRHasChanges, getRemoteBranchSha } from "./github.js";
+
+/**
+ * Describe a non-zero exit WITHOUT letting stderr impersonate the root cause.
+ *
+ * The previous form was `stderr || stdoutTail || exitCode`, which put stderr
+ * FIRST. The Claude CLI writes benign startup noise to stderr on every run — an
+ * untrusted-workspace notice, deprecation warnings — so whenever a run failed
+ * for an unrelated reason, that noise became the entire reported error and the
+ * real cause was never recorded anywhere.
+ *
+ * Observed 2026-08-04 on slashbin-io-worker cycle 1519: the run died 12.5
+ * minutes in and was reported as
+ * `Implementation failed: Ignoring 5 permissions.allow entries ...`.
+ * The identical warning appears on cycle 1520, which SUCCEEDED — so it could
+ * not have been the cause, and the actual reason is unrecoverable. Ray brought
+ * that message in as the failure; it was never even a symptom.
+ *
+ * The fix is precedence and labelling, not suppression: lead with the one
+ * unambiguous fact (the exit code), then the agent's own output, then stderr
+ * clearly marked as context. A warning can no longer appear alone, so it can no
+ * longer read as a diagnosis.
+ */
+export function describeSpawnFailure(result: { exitCode: number | null; stdout: string; stderr: string }): string {
+  // A null exit code means the process was terminated by a signal rather than
+  // returning — the OOM-killer and an abort both land here. "exit code null"
+  // would read as a missing value; say what actually happened.
+  const parts = [
+    result.exitCode === null
+      ? "terminated by signal (no exit code — killed, not returned)"
+      : `exit code ${result.exitCode}`,
+  ];
+  const stdoutTail = result.stdout.trim().slice(-500);
+  if (stdoutTail) parts.push(`stdout tail: ${stdoutTail}`);
+  const stderrMsg = result.stderr.trim().slice(-500);
+  if (stderrMsg) parts.push(`stderr (context, not necessarily the cause): ${stderrMsg}`);
+  return parts.join(" | ");
+}
+
+/**
+ * Transcript destination for a phase run, mirroring the review phase's layout
+ * (`logs/review/<repo>-cycleN-<ts>.log`).
+ *
+ * Implement and revise kept no transcript at all, so a failed implementation was
+ * unanalysable the moment it ended — there was nothing to read back. That is why
+ * cycle 1519's real failure is gone for good.
+ */
+function phaseTranscriptPath(phase: string, repoName: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return join(process.cwd(), "logs", phase, `${repoName}-${ts}.log`);
+}
 
 export interface RevisionResult {
   success: boolean;
@@ -304,7 +354,8 @@ function spawnClaude(
   prompt: string,
   config: RepoConfig,
   logger: Logger,
-  abortSignal?: AbortSignal
+  abortSignal?: AbortSignal,
+  transcriptPath?: string
 ): Promise<SpawnResult> {
   return spawnClaudeWithOptions(
     prompt,
@@ -315,6 +366,7 @@ function spawnClaude(
       allowedTools: config.allowedTools,
       maxTurns: config.maxTurns,
       maxDurationMs: config.maxDurationMs,
+      transcriptPath,
     },
     logger,
     abortSignal
@@ -393,16 +445,16 @@ Work autonomously. Do not ask questions.`;
     prompt += `\n\nIMPORTANT — PRIOR ATTEMPT FAILED: "${priorFailureReason}". Ensure you: (1) commit changes to the ${config.featureBranch} branch, (2) push to origin, (3) create a PR targeting ${config.baseBranch} using \`gh pr create\`. If a PR already exists, push new commits to it.`;
   }
 
-  const result = await spawnClaude(prompt, config, logger, abortSignal);
+  const transcriptPath = phaseTranscriptPath("implement", config.name);
+  logger.info(`Transcript: ${transcriptPath}`);
+  const result = await spawnClaude(prompt, config, logger, abortSignal, transcriptPath);
 
   if (result.timedOut) {
     return { success: false, error: "timed out" };
   }
 
   if (result.exitCode !== 0) {
-    const stderrMsg = result.stderr.trim();
-    const stdoutTail = result.stdout.trim().slice(-500);
-    const error = stderrMsg || stdoutTail || `exit code ${result.exitCode}`;
+    const error = describeSpawnFailure(result);
     logger.error(`Claude CLI exited with code ${result.exitCode}: ${error}`);
     return { success: false, error };
   }
@@ -546,16 +598,16 @@ ${IMAGE_HANDLING_INSTRUCTIONS}
 Work autonomously. Do not ask questions.`;
   }
 
-  const result = await spawnClaude(prompt, config, logger, abortSignal);
+  const transcriptPath = phaseTranscriptPath("revise", config.name);
+  logger.info(`Transcript: ${transcriptPath}`);
+  const result = await spawnClaude(prompt, config, logger, abortSignal, transcriptPath);
 
   if (result.timedOut) {
     return { success: false, error: "timed out" };
   }
 
   if (result.exitCode !== 0) {
-    const stderrMsg = result.stderr.trim();
-    const stdoutTail = result.stdout.trim().slice(-500);
-    const error = stderrMsg || stdoutTail || `exit code ${result.exitCode}`;
+    const error = describeSpawnFailure(result);
     logger.error(`Claude CLI exited with code ${result.exitCode}: ${error}`);
     return { success: false, error };
   }
@@ -673,9 +725,7 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
   }
 
   if (result.exitCode !== 0) {
-    const stderrMsg = result.stderr.trim();
-    const stdoutTail = result.stdout.trim().slice(-500);
-    const error = stderrMsg || stdoutTail || `exit code ${result.exitCode}`;
+    const error = describeSpawnFailure(result);
     logger.error(`Review Claude CLI exited with code ${result.exitCode}: ${error}`);
     return { success: false, error };
   }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,6 +10,14 @@ export interface RevisionResult {
   error?: string;
 }
 
+/** One parsed FOREMAN_REVIEW trailer line. */
+export interface ReviewTrailer {
+  pr: number;
+  verdict: string;
+  merged: boolean;
+  deploy: string;
+}
+
 export interface ReviewResult {
   success: boolean;
   error?: string;
@@ -19,31 +27,56 @@ export interface ReviewResult {
   // deployment outcome — e.g. "#100 APPROVE · merged · deploy SUCCESS". Surfaced
   // in the Foreman's Discord status line. Undefined if no trailer was emitted.
   statusLine?: string;
+  // The same trailers, structured, so the orchestrator can check the run's
+  // post-condition (did the issues it claims to have merged actually advance?).
+  trailers?: ReviewTrailer[];
 }
 
 /**
  * Parse the structured review trailers the skill is asked to emit, one per PR it
  * acted on:
  *   FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS
- * Returns a concise human-readable line, or undefined when no trailer is present.
  */
-function parseReviewTrailers(stdout: string): string | undefined {
+function parseReviewTrailerRecords(stdout: string): ReviewTrailer[] {
   // Each field uses a bounded token alphabet ([\w/-]+) so it cannot bleed into
   // surrounding characters when the trailer is emitted inside a single-line
   // stream-JSON envelope (the Claude CLI's --output-format=stream-json), where
   // the characters immediately after the trailer (`"}],"STOP_REASON":NULL,…`)
   // are non-whitespace and would be greedily absorbed by an unbounded `\S+`.
   const re = /FOREMAN_REVIEW\s+pr=#?(\d+)\s+verdict=([\w/-]+)\s+merged=([\w/-]+)\s+deploy=([\w/-]+)/gi;
-  const parts: string[] = [];
+  const out: ReviewTrailer[] = [];
   let m: RegExpExecArray | null;
   while ((m = re.exec(stdout)) !== null) {
     const [, pr, verdict, merged, deploy] = m;
-    const mergedTxt = /^y(es)?|true$/i.test(merged) ? "merged" : "not merged";
-    const deployTxt = /^(na|n\/a|none)$/i.test(deploy) ? "no deploy" : `deploy ${deploy.toUpperCase()}`;
-    parts.push(`#${pr} ${verdict.toUpperCase()} · ${mergedTxt} · ${deployTxt}`);
+    out.push({
+      pr: Number(pr),
+      verdict: verdict.toUpperCase(),
+      merged: /^(y|yes|true)$/i.test(merged),
+      deploy: deploy.toUpperCase(),
+    });
   }
-  return parts.length > 0 ? parts.join("; ") : undefined;
+  return out;
 }
+
+/** Render parsed trailers as the concise Discord status line. */
+function formatReviewTrailers(trailers: ReviewTrailer[]): string | undefined {
+  if (trailers.length === 0) return undefined;
+  return trailers
+    .map((t) => {
+      const mergedTxt = t.merged ? "merged" : "not merged";
+      const deployTxt = /^(NA|N\/A|NONE)$/.test(t.deploy) ? "no deploy" : `deploy ${t.deploy}`;
+      return `#${t.pr} ${t.verdict} · ${mergedTxt} · ${deployTxt}`;
+    })
+    .join("; ");
+}
+
+/**
+ * The explicit "there was nothing to review" sentinel. Without it, a clean no-op
+ * and a session that died mid-review are the same observation — no trailer — and
+ * the trailer gate below would have to choose which one to assume. Making the
+ * no-op DECLARE itself lets the gate treat silence as the failure it usually is.
+ */
+const REVIEW_NOOP_SENTINEL = /FOREMAN_REVIEW\s+none\b/i;
 
 export interface ImplementationResult {
   success: boolean;
@@ -599,13 +632,23 @@ Follow the skill exactly and act autonomously — do NOT ask questions or wait f
 - For BLOCKED PRs: post REQUEST_CHANGES, label the linked issue \`pr pending actions\`, and file S3/S4 follow-up issues per the skill.
 - Update issue labels yourself exactly as the skill specifies — the orchestrator will NOT relabel after you.
 
-If there are no open feature PRs awaiting review for this repo, that is a clean no-op — say so and stop.
+CRITICAL — THIS IS A HEADLESS SESSION. THERE IS NO NEXT TURN.
+Ending your turn ends the process. Anything still running is killed at that instant, and everything you had not done yet never happens.
+
+- NEVER end your turn to "wait" for something. There is nothing to wait with. Do not say "I'll wait for X to land", "let me check back", or "proceeding once this completes" — those sentences are how a merged PR gets left with a mislabeled issue forever.
+- Run post-merge verification IN THE FOREGROUND and block on it. Do NOT launch it as a background task and yield — a backgrounded verify is killed the moment you stop, so its result never arrives and the labeling step after it never runs.
+- The merge is irreversible and the labeling is not automatic. Once you merge a PR you MUST, in the same turn, finish verification and set the issue's labels. If you cannot finish, say so explicitly in your final message rather than stopping quietly.
+- If a step genuinely cannot complete (verification times out, a deploy never settles), do NOT stall — record the outcome, label the issue \`pr pending actions\`, and emit the trailer with \`deploy=FAILURE\`. A reported failure is recoverable; silence is not.
+
+If there are no open feature PRs awaiting review for this repo, that is a clean no-op — say so and emit exactly \`FOREMAN_REVIEW none\` as your final line.
 
 IMPORTANT — status trailer: After you finish, end your output with one line per PR you acted on, in EXACTLY this format (nothing after the last one):
 
 FOREMAN_REVIEW pr=#<number> verdict=<APPROVE|REQUEST_CHANGES> merged=<yes|no> deploy=<SUCCESS|FAILURE|NA>
 
 Rules for the trailer: \`merged=yes\` only if you actually merged the PR to the base branch. \`deploy=SUCCESS\`/\`deploy=FAILURE\` reflects the post-merge deployment+verification result for that merge (use \`deploy=NA\` when nothing was merged, or when the repo has no deployment to verify, e.g. a docs/CLI/npm-package repo). Emit one trailer line for every PR you reviewed this run.
+
+The trailer is MANDATORY and is the last thing you emit. A run that ends without either a \`FOREMAN_REVIEW pr=…\` line or \`FOREMAN_REVIEW none\` is recorded as a FAILED review regardless of how much work you did, because from the outside it is indistinguishable from a session that died mid-merge.
 
 ${IMAGE_HANDLING_INSTRUCTIONS}`;
 
@@ -638,7 +681,54 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
   }
 
   const summary = extractStreamResult(result.stdout);
-  const statusLine = parseReviewTrailers(result.stdout);
+
+  // Read the VERDICT out of the agent's final result text, not raw stdout.
+  // `result.stdout` is the stream-json transcript, and it opens with the prompt
+  // we just sent — which quotes the trailer format and the no-op sentinel
+  // verbatim. Scanning stdout for the sentinel therefore matches OUR OWN
+  // INSTRUCTIONS on every single run, silently declaring every dead session a
+  // clean no-op and disabling the gate below completely.
+  //
+  // The trailer regex survives stdout because the prompt's example is literally
+  // `pr=#<number>` and the pattern demands `\d+` — but that is a coincidence of
+  // the placeholder, not a guarantee. Prefer the result text; fall back to
+  // stdout only when no result event was emitted at all.
+  const trailers = parseReviewTrailerRecords(summary ?? result.stdout);
+  const declaredNoOp = summary ? REVIEW_NOOP_SENTINEL.test(summary) : false;
+  const statusLine = formatReviewTrailers(trailers);
+
+  // --- Trailer gate ------------------------------------------------------
+  // A clean exit says the PROCESS ended tidily. It says nothing about whether
+  // the REVIEW finished, and the two diverge in the one case that costs us: the
+  // agent merges the PR, then ends its turn before labeling. The session exits
+  // 0, we recorded success, reset the failure counter, and moved on — while the
+  // issue sat pinned at `pr under review` with its PR already merged, invisible
+  // to every phase (`findPRsNeedingReview` only matches OPEN PRs).
+  //
+  // Measured 2026-08-03 before this gate existed: 15 of 234 review runs (6.4%)
+  // emitted no trailer, 9 of them exiting 0 — i.e. silently booked as wins.
+  // slashbin-io-worker#564 is the worked example: merged PR #565 at 02:07Z,
+  // backgrounded its verification, ended its turn with "I'll wait for the
+  // verification run to land", and the harness killed the background tasks and
+  // exited 0.
+  //
+  // So: no trailer and no explicit no-op sentinel = FAILED, whatever the exit
+  // code claimed. This does not by itself repair anything — the merge already
+  // happened — but it converts a silent orphan into a logged, alerted failure,
+  // and the dead-zone recovery in the orchestrator takes it from there.
+  if (trailers.length === 0 && !declaredNoOp) {
+    logger.error(
+      `Review for ${repoConfig.name} exited 0 but emitted no FOREMAN_REVIEW trailer — outcome unknown; treating as FAILED${transcriptPath ? ` (transcript ${transcriptPath})` : ""}`,
+    );
+    return {
+      success: false,
+      error:
+        "no FOREMAN_REVIEW trailer emitted — the review session ended without declaring an outcome (likely stopped mid-run after merging); check the issue labels",
+      summary,
+      trailers,
+    };
+  }
+
   if (summary) {
     logger.info(`Review completed for ${repoConfig.name}:\n${summary}`);
   } else {
@@ -646,6 +736,8 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
   }
   if (statusLine) {
     logger.info(`Review outcome for ${repoConfig.name}: ${statusLine}`);
+  } else {
+    logger.info(`Review for ${repoConfig.name}: clean no-op (no PRs awaiting review)`);
   }
-  return { success: true, summary, statusLine };
+  return { success: true, summary, statusLine, trailers };
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -392,18 +392,39 @@ function spawnClaude(
   );
 }
 
+/** How much of a run's final summary is kept for logging and Discord display. */
+export const SUMMARY_DISPLAY_LIMIT = 2000;
+
 /**
  * Parse the final `result` event from a stream-json transcript and return its
- * text (truncated). Falls back to undefined when no result event is present.
+ * text IN FULL. Undefined when no result event is present.
+ *
+ * This used to `.slice(0, 2000)` before returning, which silently destroyed the
+ * outcome it was feeding. The review prompt requires the FOREMAN_REVIEW trailer to
+ * be the last thing the agent emits, so on any review whose summary exceeds 2000
+ * characters the trailer sat past the cut. The caller then parsed the truncated
+ * string, found no trailer, and — because `summary` was non-null, so the
+ * `?? result.stdout` fallback never fired — recorded a complete, correct review as
+ * "ended without declaring an outcome".
+ *
+ * Worked example, slashbin-io-worker PR #589 (2026-08-05): full result text 3,672
+ * chars, trailer at index 3,571, present in the full text and absent from the
+ * truncated one. The agent had complied exactly; the harness threw the answer away
+ * and the run was booked as FAILED.
+ *
+ * The truncation is a DISPLAY concern and now belongs at the display sites
+ * (`SUMMARY_DISPLAY_LIMIT`), never between the agent's answer and the code that
+ * reads it. Note this failure was biased toward the reviews that did the most
+ * work: the longer and more thorough the write-up, the likelier its trailer fell
+ * past the cut.
  */
-function extractStreamResult(stdout: string): string | undefined {
+export function extractStreamResult(stdout: string): string | undefined {
   const lines = stdout.split("\n").filter(Boolean);
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
       const evt = JSON.parse(lines[i]);
       if (evt && evt.type === "result") {
-        const text = typeof evt.result === "string" ? evt.result : JSON.stringify(evt);
-        return text.slice(0, 2000);
+        return typeof evt.result === "string" ? evt.result : JSON.stringify(evt);
       }
     } catch {
       // not a JSON line — keep scanning
@@ -761,7 +782,11 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
     return { success: false, error };
   }
 
-  const summary = extractStreamResult(result.stdout);
+  // Parse from the FULL result text; truncate only for display. The trailer is
+  // required to be the LAST thing the agent emits, so parsing a length-capped
+  // copy discards exactly the part that carries the outcome.
+  const fullResult = extractStreamResult(result.stdout);
+  const summary = fullResult?.slice(0, SUMMARY_DISPLAY_LIMIT);
 
   // Read the VERDICT out of the agent's final result text, not raw stdout.
   // `result.stdout` is the stream-json transcript, and it opens with the prompt
@@ -774,8 +799,8 @@ ${IMAGE_HANDLING_INSTRUCTIONS}`;
   // `pr=#<number>` and the pattern demands `\d+` — but that is a coincidence of
   // the placeholder, not a guarantee. Prefer the result text; fall back to
   // stdout only when no result event was emitted at all.
-  const trailers = parseReviewTrailerRecords(summary ?? result.stdout);
-  const declaredNoOp = summary ? REVIEW_NOOP_SENTINEL.test(summary) : false;
+  const trailers = parseReviewTrailerRecords(fullResult ?? result.stdout);
+  const declaredNoOp = fullResult ? REVIEW_NOOP_SENTINEL.test(fullResult) : false;
   const statusLine = formatReviewTrailers(trailers);
 
   // --- Trailer gate ------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,8 @@ Environment variables:
   AI_AGENT_GITHUB_REPO      GitHub repo owner/name
   AI_AGENT_TRIGGER_LABEL    Trigger label (default: approved)
   AI_AGENT_POLL_INTERVAL_MS Poll interval in ms (default: 300000)
+  AI_AGENT_ISSUE_CACHE_TTL_MS   Open-issue snapshot TTL in ms (default: 30000; 0 disables)
+  AI_AGENT_ISSUE_SNAPSHOT_LIMIT Max open issues fetched per snapshot (default: 500)
   AI_AGENT_SKILL_PATH       Path to skill file
   AI_AGENT_BASE_BRANCH      PR target branch (default: develop)
   AI_AGENT_FEATURE_BRANCH   Commit branch (default: features)

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,8 @@ const repoEntrySchema = z.object({
   model: z.string().optional(),
   maxTurns: z.coerce.number().int().positive().optional(),
   maxDurationMs: z.coerce.number().int().positive().optional(),
+  // Per-repo opt-out for the review phase (falls back to the global default).
+  reviewEnabled: z.boolean().optional(),
 });
 
 const configSchema = z.object({
@@ -41,6 +43,39 @@ const configSchema = z.object({
   allowedTools: z.array(z.string()).default(["Read", "Write", "Edit", "Bash", "Glob", "Grep"]),
   logFormat: z.enum(["json", "text"]).default("text"),
   logLevel: z.enum(["debug", "info", "warn", "error"]).default("info"),
+
+  // --- Review phase (Phase 1 in the cycle) ---
+  // Additive + OSS-safe: reviewEnabled defaults to false, so a vanilla
+  // .ai-agent.json keeps the original reconcile/revise/implement/sync/promote
+  // behavior with no review step. We opt in via our own .ai-agent.json.
+  //
+  // The review phase invokes the EM repo's /review-all-prs skill in a headless
+  // Claude session whose cwd is the EM repo (NOT the service repo) so it has the
+  // EM's MCP servers, npm scripts, and context/docs. It runs under the EM GitHub
+  // token for EM-account review attribution.
+  emRepoPath: z.string().optional(),
+  reviewEnabled: z.boolean().default(false),
+  reviewSkillPath: z.string().default(".claude/skills/review-all-prs/SKILL.md"),
+  reviewModel: z.string().optional(),
+  // The review skill is long-running (it polls Railway deploys during dev verify),
+  // so it gets a much larger turn/duration budget than implement/revise.
+  reviewMaxTurns: z.coerce.number().int().positive().default(200),
+  reviewMaxDurationMs: z.coerce.number().int().positive().default(3_600_000),
+  // Broad tool surface — the skill drives GitHub, Postgres, Redis, Railway, and
+  // the knowledge index via MCP, plus shell scripts and file reads.
+  reviewAllowedTools: z.array(z.string()).default([
+    "Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch",
+    "mcp__github__*",
+    "mcp__pg-dev-console__*", "mcp__pg-dev-worker__*",
+    "mcp__pg-prod-console__*", "mcp__pg-prod-worker__*",
+    "mcp__redis-dev-console__*", "mcp__redis-dev-ingest__*", "mcp__redis-dev-worker__*",
+    "mcp__redis-prod-console__*", "mcp__redis-prod-ingest__*", "mcp__redis-prod-worker__*",
+    "mcp__railway__*",
+    "mcp__slashbin-ai-knowledge__*",
+  ]),
+  // GitHub login the review runs as — used by the freshness guard to detect a
+  // review already posted for the current PR head (avoids re-review loops).
+  reviewerLogin: z.string().default("slashbin-engineering-manager"),
 });
 
 // --- Types ---
@@ -64,6 +99,9 @@ export interface RepoConfig {
   maxTurns: number;
   maxDurationMs: number;
   allowedTools: string[];
+  // Whether the review phase runs for this repo (resolved from per-repo override
+  // or the global reviewEnabled default).
+  reviewEnabled: boolean;
 }
 
 /**
@@ -75,6 +113,17 @@ export interface AgentConfig {
   pollIntervalMs: number;
   logFormat: "json" | "text";
   logLevel: "debug" | "info" | "warn" | "error";
+
+  // --- Review phase settings (shared across repos) ---
+  // emRepoPath is the absolute path to the EM repo whose /review-all-prs skill
+  // we invoke. Undefined when review is disabled everywhere.
+  emRepoPath?: string;
+  reviewSkillPath: string;
+  reviewModel?: string;
+  reviewMaxTurns: number;
+  reviewMaxDurationMs: number;
+  reviewAllowedTools: string[];
+  reviewerLogin: string;
 }
 
 // --- Helpers ---
@@ -126,6 +175,15 @@ export function loadConfig(configPath?: string): AgentConfig {
     logFormat: process.env.AI_AGENT_LOG_FORMAT ?? fileConfig.logFormat,
     logLevel: process.env.AI_AGENT_LOG_LEVEL ?? fileConfig.logLevel,
     repos: fileConfig.repos,
+    // Review phase
+    emRepoPath: process.env.AI_AGENT_EM_REPO_PATH ?? fileConfig.emRepoPath,
+    reviewEnabled: fileConfig.reviewEnabled,
+    reviewSkillPath: fileConfig.reviewSkillPath,
+    reviewModel: fileConfig.reviewModel,
+    reviewMaxTurns: process.env.AI_AGENT_REVIEW_MAX_TURNS ?? fileConfig.reviewMaxTurns,
+    reviewMaxDurationMs: process.env.AI_AGENT_REVIEW_MAX_DURATION_MS ?? fileConfig.reviewMaxDurationMs,
+    reviewAllowedTools: fileConfig.reviewAllowedTools,
+    reviewerLogin: fileConfig.reviewerLogin,
   };
 
   // Remove undefined keys so Zod defaults apply
@@ -169,6 +227,7 @@ export function loadConfig(configPath?: string): AgentConfig {
         model: entry.model,
         maxTurns: entry.maxTurns ?? parsed.maxTurns,
         maxDurationMs: entry.maxDurationMs ?? parsed.maxDurationMs,
+        reviewEnabled: entry.reviewEnabled ?? parsed.reviewEnabled,
         ...globals,
       };
     });
@@ -196,8 +255,20 @@ export function loadConfig(configPath?: string): AgentConfig {
       prompt: parsed.prompt,
       maxTurns: parsed.maxTurns,
       maxDurationMs: parsed.maxDurationMs,
+      reviewEnabled: parsed.reviewEnabled,
       ...globals,
     }];
+  }
+
+  // Resolve emRepoPath to absolute once (used by the review phase as the spawn cwd).
+  const emRepoPath = parsed.emRepoPath ? resolve(parsed.emRepoPath) : undefined;
+
+  // Fail fast on misconfiguration: review enabled somewhere but no EM repo path.
+  if (!emRepoPath && repos.some((r) => r.reviewEnabled)) {
+    throw new Error(
+      "reviewEnabled is true for at least one repo but emRepoPath is not set. " +
+      "Set emRepoPath (path to the EM repo holding the /review-all-prs skill) or set AI_AGENT_EM_REPO_PATH."
+    );
   }
 
   return Object.freeze({
@@ -205,5 +276,12 @@ export function loadConfig(configPath?: string): AgentConfig {
     pollIntervalMs: parsed.pollIntervalMs,
     logFormat: parsed.logFormat,
     logLevel: parsed.logLevel,
+    emRepoPath,
+    reviewSkillPath: parsed.reviewSkillPath,
+    reviewModel: parsed.reviewModel,
+    reviewMaxTurns: parsed.reviewMaxTurns,
+    reviewMaxDurationMs: parsed.reviewMaxDurationMs,
+    reviewAllowedTools: [...parsed.reviewAllowedTools],
+    reviewerLogin: parsed.reviewerLogin,
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,13 @@ const configSchema = z.object({
 
   // Global settings
   pollIntervalMs: z.coerce.number().int().positive().default(300_000),
+  // How many repos may run their pipeline at the same time. Repos are safe to
+  // run concurrently on their own — each has its own git working clone, so two
+  // can never touch the same checkout — so this cap is about SPEND, not safety:
+  // each concurrent repo means another Claude session (up to maxTurns) and
+  // another stream of GitHub API calls. Default 3; raise it deliberately after
+  // watching what it costs. Set to 1 for the original strictly-serial behaviour.
+  maxConcurrentRepos: z.coerce.number().int().positive().default(3),
   // Base window for the escalating per-issue skip back-off. The Nth consecutive
   // skip of an issue waits skipBackoffMs * 2^(N-1), capped at SKIP_BACKOFF_MAX_MS.
   // Additive + OSS-safe: defaults to the historical fixed 30 min, so an existing
@@ -117,6 +124,8 @@ export interface RepoConfig {
 export interface AgentConfig {
   repos: readonly RepoConfig[];
   pollIntervalMs: number;
+  /** Max repos running their pipeline at once (default 3). Caps spend, not risk. */
+  maxConcurrentRepos: number;
   /** Base window for the escalating per-issue skip back-off (default 30 min). */
   skipBackoffMs: number;
   logFormat: "json" | "text";
@@ -173,6 +182,7 @@ export function loadConfig(configPath?: string): AgentConfig {
     githubRepo: process.env.AI_AGENT_GITHUB_REPO ?? fileConfig.githubRepo,
     triggerLabel: process.env.AI_AGENT_TRIGGER_LABEL ?? fileConfig.triggerLabel,
     pollIntervalMs: process.env.AI_AGENT_POLL_INTERVAL_MS ?? fileConfig.pollIntervalMs,
+    maxConcurrentRepos: process.env.AI_AGENT_MAX_CONCURRENT_REPOS ?? fileConfig.maxConcurrentRepos,
     skipBackoffMs: process.env.AI_AGENT_SKIP_BACKOFF_MS ?? fileConfig.skipBackoffMs,
     skillPath: process.env.AI_AGENT_SKILL_PATH ?? fileConfig.skillPath,
     prompt: process.env.AI_AGENT_PROMPT ?? fileConfig.prompt,
@@ -283,6 +293,7 @@ export function loadConfig(configPath?: string): AgentConfig {
   return Object.freeze({
     repos: Object.freeze(repos),
     pollIntervalMs: parsed.pollIntervalMs,
+    maxConcurrentRepos: parsed.maxConcurrentRepos,
     skipBackoffMs: parsed.skipBackoffMs,
     logFormat: parsed.logFormat,
     logLevel: parsed.logLevel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,19 @@ const configSchema = z.object({
   // .ai-agent.json keeps working with no new key (the first window is unchanged;
   // only repeat skips of the SAME issue back off further). slashbin-ai-foreman#32.
   skipBackoffMs: z.coerce.number().int().positive().default(1_800_000),
+  // How long a repo's open-issue snapshot stays warm. The discovery phases each
+  // used to run their own `gh issue list` against the same repo — six GraphQL
+  // requests per repo per cycle, which at 20 repos on a 60s poll blew GitHub's
+  // 5,000/hour GraphQL ceiling and left the token permanently exhausted. One
+  // snapshot per repo per cycle serves all six. Must stay BELOW pollIntervalMs
+  // so each cycle sees fresh data; the default is half the shipped 60s floor.
+  // Set to 0 to disable caching and restore one live query per lookup.
+  // Additive + OSS-safe: an existing .ai-agent.json needs no new key.
+  issueCacheTtlMs: z.coerce.number().int().nonnegative().default(30_000),
+  // Page cap for that snapshot. It must exceed a repo's OPEN issue count, which
+  // is larger than any single label slice the old per-label queries fetched —
+  // hence 500 rather than the previous 100. Truncation is logged, never silent.
+  issueSnapshotLimit: z.coerce.number().int().positive().default(500),
   maxTurns: z.coerce.number().int().positive().default(30),
   maxDurationMs: z.coerce.number().int().positive().default(1_800_000),
   allowedTools: z.array(z.string()).default(["Read", "Write", "Edit", "Bash", "Glob", "Grep"]),
@@ -128,6 +141,10 @@ export interface AgentConfig {
   maxConcurrentRepos: number;
   /** Base window for the escalating per-issue skip back-off (default 30 min). */
   skipBackoffMs: number;
+  /** How long a repo's open-issue snapshot stays warm (default 30s; 0 disables). */
+  issueCacheTtlMs: number;
+  /** Page cap for the open-issue snapshot (default 500). */
+  issueSnapshotLimit: number;
   logFormat: "json" | "text";
   logLevel: "debug" | "info" | "warn" | "error";
 
@@ -184,6 +201,8 @@ export function loadConfig(configPath?: string): AgentConfig {
     pollIntervalMs: process.env.AI_AGENT_POLL_INTERVAL_MS ?? fileConfig.pollIntervalMs,
     maxConcurrentRepos: process.env.AI_AGENT_MAX_CONCURRENT_REPOS ?? fileConfig.maxConcurrentRepos,
     skipBackoffMs: process.env.AI_AGENT_SKIP_BACKOFF_MS ?? fileConfig.skipBackoffMs,
+    issueCacheTtlMs: process.env.AI_AGENT_ISSUE_CACHE_TTL_MS ?? fileConfig.issueCacheTtlMs,
+    issueSnapshotLimit: process.env.AI_AGENT_ISSUE_SNAPSHOT_LIMIT ?? fileConfig.issueSnapshotLimit,
     skillPath: process.env.AI_AGENT_SKILL_PATH ?? fileConfig.skillPath,
     prompt: process.env.AI_AGENT_PROMPT ?? fileConfig.prompt,
     baseBranch: process.env.AI_AGENT_BASE_BRANCH ?? fileConfig.baseBranch,
@@ -295,6 +314,8 @@ export function loadConfig(configPath?: string): AgentConfig {
     pollIntervalMs: parsed.pollIntervalMs,
     maxConcurrentRepos: parsed.maxConcurrentRepos,
     skipBackoffMs: parsed.skipBackoffMs,
+    issueCacheTtlMs: parsed.issueCacheTtlMs,
+    issueSnapshotLimit: parsed.issueSnapshotLimit,
     logFormat: parsed.logFormat,
     logLevel: parsed.logLevel,
     emRepoPath,

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,12 @@ const configSchema = z.object({
 
   // Global settings
   pollIntervalMs: z.coerce.number().int().positive().default(300_000),
+  // Base window for the escalating per-issue skip back-off. The Nth consecutive
+  // skip of an issue waits skipBackoffMs * 2^(N-1), capped at SKIP_BACKOFF_MAX_MS.
+  // Additive + OSS-safe: defaults to the historical fixed 30 min, so an existing
+  // .ai-agent.json keeps working with no new key (the first window is unchanged;
+  // only repeat skips of the SAME issue back off further). slashbin-ai-foreman#32.
+  skipBackoffMs: z.coerce.number().int().positive().default(1_800_000),
   maxTurns: z.coerce.number().int().positive().default(30),
   maxDurationMs: z.coerce.number().int().positive().default(1_800_000),
   allowedTools: z.array(z.string()).default(["Read", "Write", "Edit", "Bash", "Glob", "Grep"]),
@@ -111,6 +117,8 @@ export interface RepoConfig {
 export interface AgentConfig {
   repos: readonly RepoConfig[];
   pollIntervalMs: number;
+  /** Base window for the escalating per-issue skip back-off (default 30 min). */
+  skipBackoffMs: number;
   logFormat: "json" | "text";
   logLevel: "debug" | "info" | "warn" | "error";
 
@@ -165,6 +173,7 @@ export function loadConfig(configPath?: string): AgentConfig {
     githubRepo: process.env.AI_AGENT_GITHUB_REPO ?? fileConfig.githubRepo,
     triggerLabel: process.env.AI_AGENT_TRIGGER_LABEL ?? fileConfig.triggerLabel,
     pollIntervalMs: process.env.AI_AGENT_POLL_INTERVAL_MS ?? fileConfig.pollIntervalMs,
+    skipBackoffMs: process.env.AI_AGENT_SKIP_BACKOFF_MS ?? fileConfig.skipBackoffMs,
     skillPath: process.env.AI_AGENT_SKILL_PATH ?? fileConfig.skillPath,
     prompt: process.env.AI_AGENT_PROMPT ?? fileConfig.prompt,
     baseBranch: process.env.AI_AGENT_BASE_BRANCH ?? fileConfig.baseBranch,
@@ -274,6 +283,7 @@ export function loadConfig(configPath?: string): AgentConfig {
   return Object.freeze({
     repos: Object.freeze(repos),
     pollIntervalMs: parsed.pollIntervalMs,
+    skipBackoffMs: parsed.skipBackoffMs,
     logFormat: parsed.logFormat,
     logLevel: parsed.logLevel,
     emRepoPath,

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,24 @@ const configSchema = z.object({
   // so it gets a much larger turn/duration budget than implement/revise.
   reviewMaxTurns: z.coerce.number().int().positive().default(200),
   reviewMaxDurationMs: z.coerce.number().int().positive().default(3_600_000),
+  // After a review run, set the issue's outcome label from the run's own
+  // FOREMAN_REVIEW trailer when the skill merged the PR but left the issue at
+  // `pr under review`. Defaults to true.
+  //
+  // Default-on is safe for existing deployments because the reconciler is a
+  // REPAIR, not a policy: it only writes when the expected label is absent, only
+  // for an issue a merged PR provably closed, and only to the label the run
+  // itself reported. A skill that labels correctly never reaches the write — the
+  // behavior of a healthy pipeline is bit-for-bit unchanged. Set false to keep
+  // the label a strictly agent-owned act.
+  //
+  // NOT z.coerce.boolean(): env vars arrive as strings and Boolean("false") is
+  // true, so coercion would silently ignore the one value anyone disabling this
+  // would actually type.
+  reviewLabelReconcile: z.preprocess(
+    (v) => (typeof v === "string" ? !/^(0|false|no|off)$/i.test(v.trim()) : v),
+    z.boolean(),
+  ).default(true),
   // Broad tool surface — the skill drives GitHub, Postgres, Redis, Railway, and
   // the knowledge index via MCP, plus shell scripts and file reads.
   reviewAllowedTools: z.array(z.string()).default([
@@ -158,6 +176,7 @@ export interface AgentConfig {
   reviewMaxDurationMs: number;
   reviewAllowedTools: string[];
   reviewerLogin: string;
+  reviewLabelReconcile: boolean;
 }
 
 // --- Helpers ---
@@ -222,6 +241,7 @@ export function loadConfig(configPath?: string): AgentConfig {
     reviewMaxDurationMs: process.env.AI_AGENT_REVIEW_MAX_DURATION_MS ?? fileConfig.reviewMaxDurationMs,
     reviewAllowedTools: fileConfig.reviewAllowedTools,
     reviewerLogin: fileConfig.reviewerLogin,
+    reviewLabelReconcile: process.env.AI_AGENT_REVIEW_LABEL_RECONCILE ?? fileConfig.reviewLabelReconcile,
   };
 
   // Remove undefined keys so Zod defaults apply
@@ -325,5 +345,6 @@ export function loadConfig(configPath?: string): AgentConfig {
     reviewMaxDurationMs: parsed.reviewMaxDurationMs,
     reviewAllowedTools: [...parsed.reviewAllowedTools],
     reviewerLogin: parsed.reviewerLogin,
+    reviewLabelReconcile: parsed.reviewLabelReconcile,
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,11 @@ const configSchema = z.object({
   issueSnapshotLimit: z.coerce.number().int().positive().default(500),
   maxTurns: z.coerce.number().int().positive().default(30),
   maxDurationMs: z.coerce.number().int().positive().default(1_800_000),
+  // Model for the implement/revise phases, cascading to every repo that does not
+  // set its own. Omit to let the Claude CLI pick its default. Global because the
+  // model is a spend/quality dial for the whole fleet, not a per-repo trait —
+  // without the cascade the only way to move the fleet is to edit all 20 entries.
+  model: z.string().optional(),
   allowedTools: z.array(z.string()).default(["Read", "Write", "Edit", "Bash", "Glob", "Grep"]),
   logFormat: z.enum(["json", "text"]).default("text"),
   logLevel: z.enum(["debug", "info", "warn", "error"]).default("info"),
@@ -228,6 +233,7 @@ export function loadConfig(configPath?: string): AgentConfig {
     featureBranch: process.env.AI_AGENT_FEATURE_BRANCH ?? fileConfig.featureBranch,
     maxTurns: process.env.AI_AGENT_MAX_TURNS ?? fileConfig.maxTurns,
     maxDurationMs: process.env.AI_AGENT_MAX_DURATION_MS ?? fileConfig.maxDurationMs,
+    model: process.env.AI_AGENT_MODEL ?? fileConfig.model,
     allowedTools: fileConfig.allowedTools,
     logFormat: process.env.AI_AGENT_LOG_FORMAT ?? fileConfig.logFormat,
     logLevel: process.env.AI_AGENT_LOG_LEVEL ?? fileConfig.logLevel,
@@ -282,7 +288,7 @@ export function loadConfig(configPath?: string): AgentConfig {
         skillPath: entry.skillPath,
         revisionSkillPath: entry.revisionSkillPath,
         prompt: entry.prompt,
-        model: entry.model,
+        model: entry.model ?? parsed.model,
         maxTurns: entry.maxTurns ?? parsed.maxTurns,
         maxDurationMs: entry.maxDurationMs ?? parsed.maxDurationMs,
         reviewEnabled: entry.reviewEnabled ?? parsed.reviewEnabled,
@@ -311,6 +317,7 @@ export function loadConfig(configPath?: string): AgentConfig {
       skillPath: parsed.skillPath,
       revisionSkillPath: parsed.revisionSkillPath,
       prompt: parsed.prompt,
+      model: parsed.model,
       maxTurns: parsed.maxTurns,
       maxDurationMs: parsed.maxDurationMs,
       reviewEnabled: parsed.reviewEnabled,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -154,16 +154,33 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
       sleepResolve = null;
     }
 
-    // If currently implementing, abort with timeout
+    // If currently implementing, drain before aborting.
+    //
+    // This used to wait a flat 60s and then abort. That silently contradicted
+    // the systemd unit, which sets TimeoutStopSec=1800 precisely so a restart
+    // does NOT kill work mid-flight — systemd would wait 30 minutes while the
+    // daemon gave up after one, SIGTERMing the `claude` child and leaving a
+    // half-built branch behind. An implementation run is budgeted
+    // maxDurationMs (30 min by default), so the drain window has to match that
+    // budget, not undercut it by 30x.
+    //
+    // Override with AI_AGENT_SHUTDOWN_DRAIN_MS when you deliberately want a
+    // fast, work-destroying stop.
+    // maxDurationMs is resolved per-repo, not globally, so take the largest
+    // budget any watched repo could be mid-way through.
+    const longestRun = config.repos.reduce((m, r) => Math.max(m, r.maxDurationMs), 0);
+    const drainMs =
+      Number(process.env.AI_AGENT_SHUTDOWN_DRAIN_MS) ||
+      Math.max(longestRun, config.reviewMaxDurationMs);
     const ac = getAbortController();
     if (ac) {
-      logger.info("Waiting for in-progress implementation to finish (60s timeout)...");
-      const deadline = Date.now() + 60_000;
+      logger.info(`Waiting for in-progress implementation to finish (${Math.round(drainMs / 1000)}s timeout)...`);
+      const deadline = Date.now() + drainMs;
       while (getAbortController() && Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, 1000));
       }
       if (getAbortController()) {
-        logger.warn("Aborting in-progress implementation");
+        logger.warn("Drain window elapsed — aborting in-progress implementation");
         ac.abort();
       }
     }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "./config.js";
 import { loadConfig } from "./config.js";
 import type { Logger } from "./logger.js";
-import { runCycle, getActiveRunCount, getActiveRunRepos, abortAllRuns } from "./orchestrator.js";
+import { runRepoPass, setConcurrencyLimit, getActiveRunCount, getActiveRunRepos, getQueuedRepoCount, abortAllRuns } from "./orchestrator.js";
 import { BridgeClient, type BridgeConfig } from "./bridge-client.js";
 
 export interface DaemonOptions {
@@ -99,49 +99,109 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
     }
   }
 
-  // Continuous loop: run cycles back-to-back when there's work, sleep only when idle
-  const loop = async () => {
-    while (!stopping) {
-      cycleNumber++;
+  // --- One independent loop per repo -------------------------------------
+  //
+  // Each repo polls, works and sleeps on its OWN schedule. There is no
+  // fleet-wide barrier, so a 40-minute review on one service no longer delays
+  // every other service's next turn — which was still true after repos were
+  // merely made concurrent WITHIN a shared cycle (2026-07-29: the fleet went
+  // quiet for 24 minutes behind a single slashbin-io-worker review).
+  //
+  // What still bounds the fleet is the concurrency slot limiter in the
+  // orchestrator: a repo acquires a slot for the duration of its pass. Twenty
+  // repos waking at once queue for slots instead of opening twenty Claude
+  // sessions.
+  const repoLoops = new Map<string, { stop: () => void }>();
 
-      // Hot-reload config each cycle to pick up new repos
-      activeConfig = reloadConfig();
+  const startRepoLoop = (repoName: string): void => {
+    let loopStopping = false;
+    let wake: (() => void) | null = null;
 
-      try {
-        const { didWork, events } = await runCycle(activeConfig, logger, cycleNumber);
-
-        // Emit all cycle events to Discord bridge
-        if (bridge && events.length > 0) {
-          for (const event of events) {
-            bridge.sendStatus(`**FOREMAN:** ${event.message}`, event.level);
-          }
+    const run = async (): Promise<void> => {
+      const repoLogger = logger.child({ repo: repoName });
+      while (!stopping && !loopStopping) {
+        // Re-resolve from the live config each pass so a hot-reloaded setting
+        // (branches, budgets, reviewEnabled) applies without a restart. A repo
+        // dropped from the config ends its own loop.
+        const repoConfig = activeConfig.repos.find((r) => r.name === repoName);
+        if (!repoConfig) {
+          repoLogger.info("Repo no longer in config — stopping its loop");
+          repoLoops.delete(repoName);
+          return;
         }
 
-        // If cycle did work, immediately run the next cycle (no sleep)
-        if (didWork) continue;
-      } catch (err) {
-        logger.error("Unexpected error in cycle", {
-          cycle: cycleNumber,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        bridge?.sendStatus(`**FOREMAN:** Cycle ${cycleNumber} error — ${err instanceof Error ? err.message : String(err)}`, "error");
-      }
+        let didWork = false;
+        try {
+          const result = await runRepoPass(repoConfig, activeConfig, logger);
+          didWork = result.processed > 0;
+          if (bridge) {
+            for (const event of result.events) {
+              bridge.sendStatus(`**FOREMAN:** ${event.message}`, event.level);
+            }
+          }
+        } catch (err) {
+          // Never let one repo's failure end its loop — that would take the
+          // service permanently off the fleet with no signal beyond silence.
+          repoLogger.error("Repo pass failed", {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          bridge?.sendStatus(
+            `**FOREMAN:** ${repoName} pass error — ${err instanceof Error ? err.message : String(err)}`,
+            "error",
+          );
+        }
 
-      // No work found — sleep until next poll interval (or until stopped)
-      if (!stopping) {
+        if (didWork) continue; // more to do — go straight round again
+        if (stopping || loopStopping) return;
+
         await new Promise<void>((resolve) => {
-          sleepResolve = resolve;
+          wake = resolve;
           setTimeout(() => {
-            sleepResolve = null;
+            wake = null;
             resolve();
           }, activeConfig.pollIntervalMs);
         });
       }
+    };
+
+    repoLoops.set(repoName, {
+      stop: () => {
+        loopStopping = true;
+        if (wake) {
+          wake();
+          wake = null;
+        }
+      },
+    });
+
+    void run();
+  };
+
+  // Supervisor: hot-reload config and reconcile the set of running loops.
+  const supervisor = async (): Promise<void> => {
+    while (!stopping) {
+      cycleNumber++;
+      activeConfig = reloadConfig();
+      setConcurrencyLimit(activeConfig.maxConcurrentRepos);
+
+      for (const repo of activeConfig.repos) {
+        if (!repoLoops.has(repo.name)) startRepoLoop(repo.name);
+      }
+      for (const [name, handle] of repoLoops) {
+        if (!activeConfig.repos.some((r) => r.name === name)) handle.stop();
+      }
+
+      await new Promise<void>((resolve) => {
+        sleepResolve = resolve;
+        setTimeout(() => {
+          sleepResolve = null;
+          resolve();
+        }, activeConfig.pollIntervalMs);
+      });
     }
   };
 
-  // Start the loop (fire and forget — the loop manages its own lifecycle)
-  loop();
+  void supervisor();
 
   const stop = async (): Promise<void> => {
     if (stopping) return;
@@ -149,11 +209,13 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
 
     logger.info("Shutting down...");
 
-    // Wake from sleep if idle
+    // Wake the supervisor and every repo loop so none sits out a poll interval
+    // before noticing the shutdown.
     if (sleepResolve) {
       sleepResolve();
       sleepResolve = null;
     }
+    for (const handle of repoLoops.values()) handle.stop();
 
     // If currently implementing, drain before aborting.
     //
@@ -180,7 +242,7 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
     if (getActiveRunCount() > 0) {
       logger.info(
         `Waiting for ${getActiveRunCount()} in-progress run(s) to finish (${Math.round(drainMs / 1000)}s timeout)...`,
-        { repos: getActiveRunRepos() },
+        { repos: getActiveRunRepos(), queued: getQueuedRepoCount() },
       );
       const deadline = Date.now() + drainMs;
       while (getActiveRunCount() > 0 && Date.now() < deadline) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import { runRepoPass, setConcurrencyLimit, getActiveRunCount, getActiveRunRepos, getQueuedRepoCount, abortAllRuns } from "./orchestrator.js";
 import { BridgeClient, type BridgeConfig } from "./bridge-client.js";
+import { configureIssueCache } from "./github.js";
 
 export interface DaemonOptions {
   configPath?: string;
@@ -41,12 +42,35 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
     logger.debug("Discord bridge disabled — DISCORD_BOT_ID and DISCORD_STATUS_CHANNEL not set");
   }
 
+  // One open-issue snapshot per repo per cycle, instead of one GraphQL request
+  // per discovery lookup. See the block comment above `getOpenIssues`.
+  configureIssueCache({
+    ttlMs: config.issueCacheTtlMs,
+    snapshotLimit: config.issueSnapshotLimit,
+  });
+
+  // A TTL at or above the poll interval means a cycle can be served entirely
+  // from the previous cycle's snapshot, so an externally-applied `approved`
+  // waits an extra cycle. Legal, but almost never intended — say so.
+  if (config.issueCacheTtlMs >= config.pollIntervalMs) {
+    logger.warn(
+      "issueCacheTtlMs >= pollIntervalMs — a cycle may reuse the previous cycle's issue snapshot, delaying pickup of externally-applied labels by one cycle",
+      { issueCacheTtlMs: config.issueCacheTtlMs, pollIntervalMs: config.pollIntervalMs },
+    );
+  }
+
   const repoNames = config.repos.map((r) => r.name).join(", ");
   logger.info("Daemon starting", {
     repos: repoNames,
     repoCount: config.repos.length,
     pollInterval: `${config.pollIntervalMs / 1000}s`,
     maxConcurrentRepos: config.maxConcurrentRepos,
+    issueCacheTtlMs: config.issueCacheTtlMs,
+    // Requests/hour the discovery phases will now spend, so the budget is
+    // visible in the log rather than something you have to rediscover.
+    estDiscoveryGraphQlPerHour: Math.round(
+      config.repos.length * (3600_000 / config.pollIntervalMs),
+    ),
   });
 
   for (const repo of config.repos) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "./config.js";
 import { loadConfig } from "./config.js";
 import type { Logger } from "./logger.js";
-import { runCycle, getAbortController } from "./orchestrator.js";
+import { runCycle, getActiveRunCount, getActiveRunRepos, abortAllRuns } from "./orchestrator.js";
 import { BridgeClient, type BridgeConfig } from "./bridge-client.js";
 
 export interface DaemonOptions {
@@ -46,6 +46,7 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
     repos: repoNames,
     repoCount: config.repos.length,
     pollInterval: `${config.pollIntervalMs / 1000}s`,
+    maxConcurrentRepos: config.maxConcurrentRepos,
   });
 
   for (const repo of config.repos) {
@@ -172,16 +173,22 @@ export function startDaemon(config: AgentConfig, logger: Logger, options?: Daemo
     const drainMs =
       Number(process.env.AI_AGENT_SHUTDOWN_DRAIN_MS) ||
       Math.max(longestRun, config.reviewMaxDurationMs);
-    const ac = getAbortController();
-    if (ac) {
-      logger.info(`Waiting for in-progress implementation to finish (${Math.round(drainMs / 1000)}s timeout)...`);
+    // Several repos can be mid-run at once now, so drain ALL of them. Waiting on
+    // a single controller would have returned as soon as the first one finished
+    // and left the rest to be SIGKILLed with half-built branches — the exact
+    // outcome TimeoutStopSec=1800 exists to prevent.
+    if (getActiveRunCount() > 0) {
+      logger.info(
+        `Waiting for ${getActiveRunCount()} in-progress run(s) to finish (${Math.round(drainMs / 1000)}s timeout)...`,
+        { repos: getActiveRunRepos() },
+      );
       const deadline = Date.now() + drainMs;
-      while (getAbortController() && Date.now() < deadline) {
+      while (getActiveRunCount() > 0 && Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, 1000));
       }
-      if (getAbortController()) {
-        logger.warn("Drain window elapsed — aborting in-progress implementation");
-        ac.abort();
+      if (getActiveRunCount() > 0) {
+        logger.warn("Drain window elapsed — aborting in-progress run(s)", { repos: getActiveRunRepos() });
+        abortAllRuns();
       }
     }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -427,6 +427,15 @@ export interface ReviewCandidate {
  * remaining window where a review run crashed after posting its verdict but before
  * relabeling — without it the same PR would be re-reviewed every cycle.
  *
+ * Self-heal fallback: when no issue carries `pr under review` but an open feature
+ * PR exists, the implement phase opened the PR but never applied the label (the
+ * transition step swallows errors, and the process can die between `gh pr create`
+ * and `transitionImplementationLabels`). GitHub — the actual open PR — is the
+ * source of truth for whether review is needed; the label is a tracking artifact.
+ * `adoptOrphanedReviewCandidate` finds linked issues from the PR title/body,
+ * applies `pr under review` to them, and returns the candidate so the review runs
+ * this cycle instead of hanging forever waiting for a label that never lands.
+ *
  * Returns null when there's nothing to review.
  */
 export function findPRsNeedingReview(
@@ -447,7 +456,9 @@ export function findPRsNeedingReview(
     const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
     // Exclude issues also labeled `pr pending actions` — the revise phase owns those.
     const reviewable = issues.filter((i) => !i.labels.some((l) => l.name === "pr pending actions"));
-    if (reviewable.length === 0) return null;
+    if (reviewable.length === 0) {
+      return adoptOrphanedReviewCandidate(config, reviewerLogin, logger);
+    }
 
     // Confirm an open feature PR exists (features → develop).
     const prJson = gh([
@@ -482,6 +493,90 @@ export function findPRsNeedingReview(
     });
     return null;
   }
+}
+
+/**
+ * Fallback for `findPRsNeedingReview`: an open feature PR exists but no linked
+ * issue carries `pr under review`. The implement phase opened the PR then failed
+ * (silently) to apply the label — or crashed between `gh pr create` and
+ * `transitionImplementationLabels`. Recover by extracting linked issue refs from
+ * the PR title/body, applying `pr under review` to those that still carry the
+ * trigger label, and returning a candidate so the review runs this cycle.
+ *
+ * Safety filters (only adopt issues we clearly own):
+ *  - OPEN state
+ *  - carries `config.triggerLabel` (default `approved`)
+ *  - NOT `pr pending actions` (revise phase owns those)
+ *  - NOT `ready for prod release` (already advanced)
+ */
+function adoptOrphanedReviewCandidate(
+  config: RepoConfig,
+  reviewerLogin: string,
+  logger: Logger,
+): ReviewCandidate | null {
+  const prJson = gh([
+    "pr", "list",
+    "--repo", config.githubRepo,
+    "--state", "open",
+    "--head", config.featureBranch,
+    "--base", config.baseBranch,
+    "--json", "number,url,title,body",
+    "--limit", "1",
+  ], config.repoPath);
+
+  const prs: { number: number; url: string; title: string; body: string }[] = JSON.parse(prJson || "[]");
+  if (prs.length === 0) return null;
+  const pr = prs[0];
+
+  if (hasFreshReview(config, pr.number, reviewerLogin, logger)) return null;
+
+  const refs = new Set<number>();
+  const combined = `${pr.title}\n${pr.body ?? ""}`;
+  for (const m of combined.matchAll(/#(\d+)/g)) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n !== pr.number) refs.add(n);
+  }
+  if (refs.size === 0) {
+    logger.debug(`${config.name}: PR #${pr.number} has no "pr under review" label and no linked issues found in title/body`);
+    return null;
+  }
+
+  const adopted: number[] = [];
+  for (const num of refs) {
+    try {
+      const raw = gh([
+        "issue", "view", String(num),
+        "--repo", config.githubRepo,
+        "--json", "state,labels",
+      ], config.repoPath);
+      const info: { state: string; labels: { name: string }[] } = JSON.parse(raw);
+      if (info.state !== "OPEN") continue;
+      const names = new Set(info.labels.map((l) => l.name));
+      if (!names.has(config.triggerLabel)) continue;
+      if (names.has("pr pending actions")) continue;
+      if (names.has("ready for prod release")) continue;
+      try {
+        gh([
+          "issue", "edit", String(num),
+          "--repo", config.githubRepo,
+          "--add-label", "pr under review",
+        ], config.repoPath);
+        logger.warn(`${config.name}: adopted orphaned issue #${num} → PR #${pr.number} (implement phase never applied "pr under review")`);
+      } catch (err) {
+        logger.warn(`${config.name}: failed to add "pr under review" on adopted #${num}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      adopted.push(num);
+    } catch (err) {
+      logger.debug(`${config.name}: could not inspect referenced #${num}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (adopted.length === 0) {
+    logger.debug(`${config.name}: PR #${pr.number} is orphaned but no referenced issue is a review candidate (missing ${config.triggerLabel}, or owned by revise/prod)`);
+    return null;
+  }
+
+  logger.info(`${config.name}: adopted orphaned PR #${pr.number} for review (issues: ${adopted.map((n) => `#${n}`).join(", ")})`);
+  return { prNumber: pr.number, prUrl: pr.url, issueNumbers: adopted };
 }
 
 export interface StuckMergedIssue {

--- a/src/github.ts
+++ b/src/github.ts
@@ -2,14 +2,6 @@ import { execFileSync } from "node:child_process";
 import type { RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 
-interface GhIssue {
-  number: number;
-  title: string;
-  body: string;
-  labels: { name: string }[];
-  url: string;
-}
-
 const GH_MAX_ATTEMPTS = 3;
 const GH_BACKOFF_MS = [1000, 3000, 9000];
 
@@ -40,6 +32,28 @@ function isTransientGhError(err: unknown): boolean {
   );
 }
 
+/**
+ * A rate-limit rejection is NOT transient — retrying it inside the same cycle
+ * only spends more of an already-exhausted budget. It gets its own classifier
+ * for one reason: so it is *nameable* in the log.
+ *
+ * 2026-07-30: the daemon emitted 22,466 of these in 24 hours (~1,100/hour,
+ * unbroken for 21+ hours) and every one surfaced as a generic
+ * "Failed to check for approved issues" — the same line a real outage prints.
+ * A quota problem that is indistinguishable from a dead Foreman is a
+ * diagnosability defect on top of the quota defect, so we label it explicitly.
+ */
+function isRateLimitGhError(err: unknown): boolean {
+  const { message, stderr } = formatGhError(err);
+  const blob = `${message}\n${stderr}`.toLowerCase();
+  return (
+    blob.includes("api rate limit already exceeded") ||
+    blob.includes("api rate limit exceeded") ||
+    blob.includes("secondary rate limit") ||
+    blob.includes("was submitted too quickly")
+  );
+}
+
 /** execFileSync gh with retry+backoff on transient (network/5xx/timeout) failures. */
 function runGh(args: string[], cwd: string, token: string): string {
   let lastErr: unknown;
@@ -54,6 +68,12 @@ function runGh(args: string[], cwd: string, token: string): string {
       }).trim();
     } catch (err) {
       lastErr = err;
+      if (isRateLimitGhError(err)) {
+        // Deliberately not retried: the budget is already gone. Name it loudly
+        // and once, then let the caller's own error path handle the cycle.
+        console.warn(`[gh] RATE LIMIT EXHAUSTED — GitHub API quota is spent, skipping: gh ${args.slice(0, 3).join(" ")}`);
+        throw err;
+      }
       if (attempt < GH_MAX_ATTEMPTS && isTransientGhError(err)) {
         const wait = GH_BACKOFF_MS[attempt - 1];
         const { message, stderr } = formatGhError(err);
@@ -71,6 +91,7 @@ function runGh(args: string[], cwd: string, token: string): string {
 export function gh(args: string[], cwd: string): string {
   const foremanToken = process.env.FOREMAN_GITHUB_TOKEN;
   if (!foremanToken) throw new Error("FOREMAN_GITHUB_TOKEN not set — cannot operate as Foreman");
+  invalidateSnapshotIfMutating(args);
   return runGh(args, cwd, foremanToken);
 }
 
@@ -78,7 +99,117 @@ export function gh(args: string[], cwd: string): string {
 function ghAsEM(args: string[], cwd: string): string {
   const emToken = process.env.EM_GITHUB_TOKEN;
   if (!emToken) throw new Error("EM_GITHUB_TOKEN not set — cannot approve/merge as EM");
+  invalidateSnapshotIfMutating(args);
   return runGh(args, cwd, emToken);
+}
+
+// ---------------------------------------------------------------------------
+// Open-issue snapshot: one `gh issue list` per repo per cycle
+// ---------------------------------------------------------------------------
+
+/**
+ * The six discovery lookups in this file (`approved` ×2, `pr under review` ×2,
+ * `pr pending actions`, `ready for prod release`) each used to issue their own
+ * `gh issue list --state open` against the SAME repo. Every `gh issue list`
+ * spends a GraphQL request, and GraphQL is capped at 5,000/hour per token.
+ *
+ * 2026-07-30: 20 repos × ~6 lookups × a 60s poll interval ≈ 7,200 GraphQL
+ * calls/hour against that 5,000 ceiling. The Foreman token sat permanently
+ * exhausted — 22,466 rejections in 24 hours — so roughly one lookup in six
+ * failed outright. A failed lookup silently skips that phase for that repo
+ * that cycle: an `approved` issue goes unimplemented, a
+ * `ready for prod release` unpromoted, recovering only on a later cycle that
+ * happens to win the quota race.
+ *
+ * The fix is that all six lookups are label subsets of ONE query. We fetch
+ * `--state open` once per repo, cache it briefly, and filter in memory:
+ * 6 calls → 1 (≈1,200/hour, comfortably inside budget) with the poll interval
+ * left where operations wants it at 60s. Fetching every open issue instead of
+ * a label-filtered slice costs no extra requests — the request count is driven
+ * by pages, not by predicates.
+ *
+ * Correctness: the snapshot is dropped whenever the Foreman mutates an issue in
+ * that repo (see `invalidateSnapshotIfMutating`), so a label written by an
+ * earlier phase is never read back stale later in the same cycle. A label
+ * changed EXTERNALLY — the EM applying `approved` — is picked up on the next
+ * refresh, i.e. at worst one TTL late, which is a delay the poll interval
+ * already implies.
+ *
+ * Additive and OSS-safe: `issueCacheTtlMs: 0` restores the old behaviour of one
+ * live query per lookup.
+ */
+interface IssueSnapshot {
+  number: number;
+  title: string;
+  labels: { name: string }[];
+}
+
+const DEFAULT_ISSUE_CACHE_TTL_MS = 30_000;
+const DEFAULT_ISSUE_SNAPSHOT_LIMIT = 500;
+
+let issueCacheTtlMs = DEFAULT_ISSUE_CACHE_TTL_MS;
+let issueSnapshotLimit = DEFAULT_ISSUE_SNAPSHOT_LIMIT;
+const issueSnapshots = new Map<string, { fetchedAt: number; issues: IssueSnapshot[] }>();
+
+/**
+ * Apply daemon-level cache settings. Called once at startup; defaults stand if
+ * it is never called, so nothing downstream has to know this exists.
+ */
+export function configureIssueCache(opts: { ttlMs?: number; snapshotLimit?: number }): void {
+  if (typeof opts.ttlMs === "number" && Number.isFinite(opts.ttlMs) && opts.ttlMs >= 0) {
+    issueCacheTtlMs = opts.ttlMs;
+  }
+  if (typeof opts.snapshotLimit === "number" && Number.isFinite(opts.snapshotLimit) && opts.snapshotLimit > 0) {
+    issueSnapshotLimit = Math.floor(opts.snapshotLimit);
+  }
+  issueSnapshots.clear();
+}
+
+/**
+ * Drop a repo's cached snapshot when a command mutates issue state, so a later
+ * phase re-reads what this cycle just wrote. Keyed off the `--repo` argument;
+ * `list`/`view` are reads and left alone.
+ */
+function invalidateSnapshotIfMutating(args: string[]): void {
+  if (args[0] !== "issue") return;
+  if (args[1] === "list" || args[1] === "view") return;
+  const i = args.indexOf("--repo");
+  const repo = i >= 0 ? args[i + 1] : undefined;
+  if (repo) issueSnapshots.delete(repo);
+}
+
+/** Every open issue in the repo, from cache when warm. */
+function getOpenIssues(repo: string, cwd: string, logger: Logger): IssueSnapshot[] {
+  const cached = issueSnapshots.get(repo);
+  if (cached && issueCacheTtlMs > 0 && Date.now() - cached.fetchedAt < issueCacheTtlMs) {
+    return cached.issues;
+  }
+
+  const json = gh([
+    "issue", "list",
+    "--repo", repo,
+    "--state", "open",
+    "--json", "number,title,labels",
+    "--limit", String(issueSnapshotLimit),
+  ], cwd);
+  const issues: IssueSnapshot[] = JSON.parse(json || "[]");
+
+  // No silent caps. Hitting the limit means discovery may be blind to issues it
+  // is supposed to see, which would look exactly like "no work to do".
+  if (issues.length >= issueSnapshotLimit) {
+    logger.warn(
+      "Open-issue snapshot hit its limit — discovery may be missing issues; raise issueSnapshotLimit",
+      { repo, limit: issueSnapshotLimit, returned: issues.length },
+    );
+  }
+
+  if (issueCacheTtlMs > 0) issueSnapshots.set(repo, { fetchedAt: Date.now(), issues });
+  return issues;
+}
+
+/** True when `issue` carries a label named `name`. */
+function hasLabel(issue: IssueSnapshot, name: string): boolean {
+  return issue.labels.some((l) => l.name === name);
 }
 
 /**
@@ -133,15 +264,8 @@ export function findAllApprovedActionableIssues(
 ): number[] {
   const repo = config.githubRepo;
   try {
-    const json = gh([
-      "issue", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--label", config.triggerLabel,
-      "--json", "number,labels",
-      "--limit", "100",
-    ], config.repoPath);
-    const issues: GhIssue[] = JSON.parse(json || "[]");
+    const issues = getOpenIssues(repo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, config.triggerLabel));
 
     const lifecycleLabels = [
       "pr under review",
@@ -241,16 +365,8 @@ export function findActionableIssues(
   const repo = config.githubRepo;
 
   try {
-    const json = gh([
-      "issue", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--label", config.triggerLabel,
-      "--json", "number,labels",
-      "--limit", "100",
-    ], config.repoPath);
-
-    const issues: GhIssue[] = JSON.parse(json || "[]");
+    const issues = getOpenIssues(repo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, config.triggerLabel));
 
     const lifecycleLabels = [
       "pr under review",
@@ -379,17 +495,8 @@ export function findPendingRevisions(
 ): PendingRevisionInfo | null {
   try {
     // Find issues labeled "pr pending actions" + the trigger label (approved)
-    const issueJson = gh([
-      "issue", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--label", "pr pending actions",
-      "--label", config.triggerLabel,
-      "--json", "number,title",
-      "--limit", "100",
-    ], config.repoPath);
-
-    const issues: { number: number; title: string }[] = JSON.parse(issueJson || "[]");
+    const issues = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, "pr pending actions") && hasLabel(i, config.triggerLabel));
     if (issues.length === 0) return null;
 
     // Confirm there's an open feature PR (features → develop)
@@ -462,18 +569,10 @@ export function findPRsNeedingReview(
   logger: Logger,
 ): ReviewCandidate | null {
   try {
-    const issueJson = gh([
-      "issue", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--label", "pr under review",
-      "--json", "number,labels",
-      "--limit", "100",
-    ], config.repoPath);
-
-    const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
+    const issues = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, "pr under review"));
     // Exclude issues also labeled `pr pending actions` — the revise phase owns those.
-    const reviewable = issues.filter((i) => !i.labels.some((l) => l.name === "pr pending actions"));
+    const reviewable = issues.filter((i) => !hasLabel(i, "pr pending actions"));
     if (reviewable.length === 0) {
       return adoptOrphanedReviewCandidate(config, reviewerLogin, logger);
     }
@@ -755,18 +854,11 @@ export function findStuckMergedIssues(
 ): StuckMergedIssue[] {
   if (config.baseBranch === config.featureBranch) return [];
   try {
-    const issueJson = gh([
-      "issue", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--label", "pr under review",
-      "--json", "number,labels",
-      "--limit", "100",
-    ], config.repoPath);
-    const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
+    const issues = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, "pr under review"));
     const candidates = issues.filter(
-      (i) => !i.labels.some(
-        (l) => l.name === "pr pending actions" || l.name === "pr approved" || l.name === "ready for prod release",
+      (i) => !(
+        hasLabel(i, "pr pending actions") || hasLabel(i, "pr approved") || hasLabel(i, "ready for prod release")
       ),
     );
     if (candidates.length === 0) return [];
@@ -909,16 +1001,9 @@ export function findReadyForProdIssues(
   logger: Logger
 ): PromotionIssue[] {
   try {
-    const json = gh([
-      "issue", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--label", "ready for prod release",
-      "--json", "number,title",
-      "--limit", "100",
-    ], cwd);
-
-    return JSON.parse(json || "[]");
+    return getOpenIssues(repo, cwd, logger)
+      .filter((i) => hasLabel(i, "ready for prod release"))
+      .map((i) => ({ number: i.number, title: i.title }));
   } catch (err) {
     logger.error("Failed to query ready-for-prod issues", {
       error: err instanceof Error ? err.message : String(err),

--- a/src/github.ts
+++ b/src/github.ts
@@ -590,8 +590,28 @@ export function findPendingRevisions(
 ): PendingRevisionInfo | null {
   try {
     // Find issues labeled "pr pending actions" + the trigger label (approved)
-    const issues = getOpenIssues(config.githubRepo, config.repoPath, logger)
-      .filter((i) => hasLabel(i, "pr pending actions") && hasLabel(i, config.triggerLabel));
+    const pendingActions = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .filter((i) => hasLabel(i, "pr pending actions"));
+    const issues = pendingActions.filter((i) => hasLabel(i, config.triggerLabel));
+
+    // An issue asked to revise but no longer carrying the trigger label is
+    // SKIPPED here, and that is deliberate — revoking `approved` is how work is
+    // called off, and revise must honour it rather than press on.
+    //
+    // But silent is wrong. The issue keeps `pr pending actions`, so
+    // `findActionableIssues` skips it too, and it belongs to no phase at all.
+    // Deliberately stopped and accidentally stranded produced the identical
+    // observation — nothing — until this line existed. Say which one it is.
+    const withheld = pendingActions.filter((i) => !hasLabel(i, config.triggerLabel));
+    if (withheld.length > 0) {
+      logger.warn(
+        `${config.name}: ${withheld.length} issue(s) labeled "pr pending actions" without "${config.triggerLabel}" — ` +
+        `revise will NOT act on them and no other phase owns them. Intentional if the work was called off; ` +
+        `otherwise re-apply "${config.triggerLabel}" or clear the lifecycle label: ` +
+        withheld.map((i) => `#${i.number}`).join(", "),
+      );
+    }
+
     if (issues.length === 0) return null;
 
     // Confirm there's an open feature PR (features → develop)
@@ -925,11 +945,17 @@ const STUCK_MERGE_GRACE_MS = 15 * 60 * 1000;
  *
  * Conservative by design (returns [] on any ambiguity):
  *  - skips main-only repos (no features→develop lifecycle)
- *  - ignores issues also labeled `pr pending actions` (revise owns) or
- *    `ready for prod release` (already advanced)
+ *  - ignores `pr approved` / `ready for prod release` (already advanced)
  *  - ignores issues REFERENCED BY an open feature PR (normal review-pending;
  *    tryReview owns those specific issues)
  *  - only flags PRs merged more than STUCK_MERGE_GRACE_MS ago (no flap on fresh merges)
+ *
+ * `pr pending actions` USED to be excluded here on the grounds that "revise owns
+ * it". That was only true while a feature PR is open: `findPendingRevisions`
+ * returns null the moment there is none, at `debug` level, so a revision request
+ * whose PR merged or closed underneath it was owned by nobody and logged
+ * nowhere. It is the same dead zone as `pr under review`, one label over, and it
+ * is now included.
  */
 export function findStuckMergedIssues(
   config: RepoConfig,
@@ -938,10 +964,10 @@ export function findStuckMergedIssues(
   if (config.baseBranch === config.featureBranch) return [];
   try {
     const issues = getOpenIssues(config.githubRepo, config.repoPath, logger)
-      .filter((i) => hasLabel(i, "pr under review"));
+      .filter((i) => hasLabel(i, "pr under review") || hasLabel(i, "pr pending actions"));
     const candidates = issues.filter(
       (i) => !(
-        hasLabel(i, "pr pending actions") || hasLabel(i, "pr approved") || hasLabel(i, "ready for prod release")
+        hasLabel(i, "pr approved") || hasLabel(i, "ready for prod release")
       ),
     );
     if (candidates.length === 0) return [];
@@ -1002,6 +1028,127 @@ export function findStuckMergedIssues(
       `findStuckMergedIssues failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return [];
+  }
+}
+
+/**
+ * Detect issues ORPHANED by work that never landed: labeled `pr under review`
+ * or `pr pending actions`, with **no open feature PR covering them and nothing
+ * merged to the base branch**. The PR was closed without merging, or the
+ * implement run recorded a label and then died before opening one.
+ *
+ * This is the third dead zone and the only one where the work does not exist:
+ *
+ *   | label               | PR open   | PR merged        | PR closed / none |
+ *   |---------------------|-----------|------------------|------------------|
+ *   | pr under review     | tryReview | findStuckMerged  | HERE             |
+ *   | pr pending actions  | tryRevise | findStuckMerged  | HERE             |
+ *
+ * The lifecycle label is what makes it invisible: `findActionableIssues` skips
+ * ANY issue carrying one, so an issue whose PR vanished keeps its `approved`
+ * label, is never re-implemented, is never reviewed, and produces no log line
+ * above `debug`. It simply stops existing as far as the pipeline is concerned.
+ *
+ * Recovery is the opposite of the merged case: there is nothing to verify, so
+ * the correct action is to RETURN IT TO THE QUEUE — strip the lifecycle label
+ * and let the implement phase pick it up again on its `approved` label. That is
+ * safe precisely because nothing merged; re-implementing cannot duplicate work
+ * that does not exist.
+ *
+ * Conservative by design:
+ *  - skips main-only repos
+ *  - ignores `pr approved` / `ready for prod release` (past this stage)
+ *  - ignores issues an open feature PR references, and fails CLOSED when that
+ *    reference list is unreadable
+ *  - requires the issue to have been in this state longer than the grace window,
+ *    so a PR being opened right now is never mistaken for one that never was
+ */
+export function findOrphanedLifecycleIssues(
+  config: RepoConfig,
+  logger: Logger,
+): number[] {
+  if (config.baseBranch === config.featureBranch) return [];
+  try {
+    const open = getOpenIssues(config.githubRepo, config.repoPath, logger);
+    const candidates = open.filter(
+      (i) =>
+        (hasLabel(i, "pr under review") || hasLabel(i, "pr pending actions")) &&
+        !hasLabel(i, "pr approved") &&
+        !hasLabel(i, "ready for prod release"),
+    );
+    if (candidates.length === 0) return [];
+
+    const openFeaturePrs = findOpenPrs(config.githubRepo, config.repoPath, {
+      head: config.featureBranch,
+      base: config.baseBranch,
+      limit: 1,
+    });
+    let reviewPending: number[] = [];
+    if (openFeaturePrs.length > 0) {
+      const referenced = getReferencedIssuesFromOpenPR(
+        config.githubRepo,
+        config.featureBranch,
+        config.baseBranch,
+        config.repoPath,
+        logger,
+      );
+      // Unreadable reference list — cannot tell what the open PR covers, so
+      // releasing anything risks re-implementing work that is in flight.
+      if (referenced === null) return [];
+      reviewPending = referenced;
+    }
+
+    const unowned = candidates.filter((i) => !reviewPending.includes(i.number));
+    if (unowned.length === 0) return [];
+
+    // Anything already merged belongs to findStuckMergedIssues, which re-verifies
+    // rather than re-queues. Only what NEVER landed is an orphan.
+    const merged = new Set(
+      findIssuesMergedToBase(config, unowned.map((i) => i.number), logger).map((m) => m.issueNumber),
+    );
+
+    return unowned.filter((i) => !merged.has(i.number)).map((i) => i.number);
+  } catch (err) {
+    logger.debug(
+      `findOrphanedLifecycleIssues failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Return an orphaned issue to the implement queue by stripping whichever
+ * lifecycle label is stranding it. The trigger label (`approved`) is left alone
+ * — it is still authorized, it just never got built.
+ */
+export function releaseOrphanedLifecycle(
+  config: RepoConfig,
+  issueNumber: number,
+  logger: Logger,
+): boolean {
+  try {
+    dropIssueSnapshot(config.githubRepo);
+    const issue = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .find((i) => i.number === issueNumber);
+    if (!issue) return false;
+
+    const args = ["issue", "edit", String(issueNumber), "--repo", config.githubRepo];
+    // `gh` errors when removing a label that is not present, so only remove what is.
+    if (hasLabel(issue, "pr under review")) args.push("--remove-label", "pr under review");
+    if (hasLabel(issue, "pr pending actions")) args.push("--remove-label", "pr pending actions");
+    if (args.length === 5) return false; // nothing to strip — state changed under us
+
+    gh(args, config.repoPath);
+    logger.warn(
+      `Released orphaned issue #${issueNumber} back to the implement queue — it carried a lifecycle label ` +
+      `but no open PR covers it and nothing merged, so the work never landed.`,
+    );
+    return true;
+  } catch (err) {
+    logger.warn(
+      `Failed to release orphaned issue #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
   }
 }
 
@@ -1247,14 +1394,39 @@ export function resolveDeadZone(
 ): boolean {
   const nextLabel = verdict === "pass" ? "pr approved" : "pr pending actions";
   try {
-    gh([
-      "issue", "edit", String(issueNumber),
-      "--repo", config.githubRepo,
-      "--remove-label", "pr under review",
-      "--add-label", nextLabel,
-    ], config.repoPath);
+    // Remove only what is actually present. `gh` errors on removing an absent
+    // label, and since the dead zone now covers `pr pending actions` as well as
+    // `pr under review`, a hard `--remove-label "pr under review"` would throw
+    // on exactly the issues the widened detector just started catching — the
+    // recovery would fail for the new case while looking like a gh outage.
+    dropIssueSnapshot(config.githubRepo);
+    const issue = getOpenIssues(config.githubRepo, config.repoPath, logger)
+      .find((i) => i.number === issueNumber);
+    if (!issue) {
+      logger.debug(`Dead-zone resolve skipped for #${issueNumber} — no longer open`);
+      return false;
+    }
+
+    const args = ["issue", "edit", String(issueNumber), "--repo", config.githubRepo];
+    const stripped: string[] = [];
+    for (const l of ["pr under review", "pr pending actions"]) {
+      // Never strip the label we are about to add — that is a no-op edit that
+      // reads as a transition.
+      if (l !== nextLabel && hasLabel(issue, l)) {
+        args.push("--remove-label", l);
+        stripped.push(l);
+      }
+    }
+    if (!hasLabel(issue, nextLabel)) args.push("--add-label", nextLabel);
+    if (args.length === 4) {
+      logger.debug(`Dead-zone resolve on #${issueNumber} is already in the target state`);
+      return false;
+    }
+
+    gh(args, config.repoPath);
     logger.info(
-      `Dead-zone resolved on #${issueNumber}: removed "pr under review", added "${nextLabel}" (re-verification ${verdict.toUpperCase()})`,
+      `Dead-zone resolved on #${issueNumber}: removed ${stripped.map((s) => `"${s}"`).join(", ") || "(nothing)"}, ` +
+      `added "${nextLabel}" (re-verification ${verdict.toUpperCase()})`,
     );
     return true;
   } catch (err) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -980,17 +980,36 @@ ${issueList}
 ---
 Automated by slashbin-ai-agent`;
 
+  // REST, NOT `gh pr edit` (2026-07-27).
+  //
+  // `gh pr edit` resolves the PR through GraphQL and requests `projectCards` —
+  // GitHub's Projects *classic*, now sunset. The API rejects that field, gh
+  // exits 1, and the edit DOES NOT APPLY:
+  //
+  //   GraphQL: Projects (classic) is being deprecated in favor of the new
+  //   Projects experience (repository.pullRequest.projectCards)
+  //
+  // Reproduced twice against jerky_data_receiver#241 — exit 1, title unchanged.
+  // This silently blocked EVERY repo that already had an open promotion PR,
+  // from ~04:11Z until it was found at ~21:10Z: the promote phase kept logging
+  // "Found N issue(s) ready for prod release" and then failing to act. Creating
+  // a NEW promotion PR still worked, which is why some promotions got through
+  // and others did not — a confusing signal that delayed the diagnosis.
+  //
+  // The REST endpoint touches no Projects field at all, so the deprecation
+  // cannot affect it. Do not "simplify" this back to `gh pr edit`.
+  const [owner, name] = repo.split("/");
   try {
     gh([
-      "pr", "edit", String(prNumber),
-      "--repo", repo,
-      "--title", title,
-      "--body", body,
+      "api", "--method", "PATCH",
+      `repos/${owner}/${name}/pulls/${prNumber}`,
+      "-f", `title=${title}`,
+      "-f", `body=${body}`,
+      "--silent",
     ], cwd);
     return true;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // Log stderr if available from execFileSync
     const stderr = (err as { stderr?: string }).stderr ?? "";
     console.error(`updatePromotionPR failed: ${msg}${stderr ? ` | stderr: ${stderr}` : ""}`);
     return false;

--- a/src/github.ts
+++ b/src/github.ts
@@ -1633,6 +1633,8 @@ export function getRemoteBranchSha(
 export interface BranchDrift {
   developBehindMain: number;
   developAheadOfMain: number;
+  /** Files differing between main and develop. Zero means merge-commit-only drift. */
+  developAheadFiles: number;
 }
 
 /**
@@ -1647,13 +1649,19 @@ export function checkBranchDrift(
   try {
     const json = gh([
       "api", `repos/${repo}/compare/main...develop`,
-      "--jq", '{"ahead": .ahead_by, "behind": .behind_by}',
+      "--jq", '{"ahead": .ahead_by, "behind": .behind_by, "files": ((.files // []) | length)}',
     ], cwd);
 
     const result = JSON.parse(json);
     return {
       developAheadOfMain: result.ahead,
       developBehindMain: result.behind,
+      // Changed files between main and develop. `ahead > 0 && files === 0` is the
+      // NORMAL steady state, not a stall: the main -> develop sync PR leaves a
+      // merge commit on develop that main does not have, carrying no file change.
+      // Counting commits alone flags every repo, forever. GitHub truncates this
+      // array on very large diffs but never empties it, so 0 really means 0.
+      developAheadFiles: result.files ?? 0,
     };
   } catch (err) {
     logger.error("Failed to check branch drift", {

--- a/src/github.ts
+++ b/src/github.ts
@@ -364,6 +364,124 @@ export function hasPendingRevisions(
   return findPendingRevisions(config, logger) !== null;
 }
 
+export interface ReviewCandidate {
+  prNumber: number;
+  prUrl: string;
+  issueNumbers: number[];
+}
+
+/**
+ * Gate check for the review phase: is there an open feature PR whose linked
+ * issue(s) are labeled `pr under review` (set by implement/revise) and that has
+ * NOT already been reviewed by the EM at its current head?
+ *
+ * Idempotency is primarily label-driven and self-cleaning: a full-fidelity review
+ * run either merges an approved PR (closes it → out of scope here) or posts
+ * REQUEST_CHANGES and relabels the issue `pr pending actions` (→ owned by the
+ * revise phase, excluded below). The freshness guard (`hasFreshReview`) covers the
+ * remaining window where a review run crashed after posting its verdict but before
+ * relabeling — without it the same PR would be re-reviewed every cycle.
+ *
+ * Returns null when there's nothing to review.
+ */
+export function findPRsNeedingReview(
+  config: RepoConfig,
+  reviewerLogin: string,
+  logger: Logger,
+): ReviewCandidate | null {
+  try {
+    const issueJson = gh([
+      "issue", "list",
+      "--repo", config.githubRepo,
+      "--state", "open",
+      "--label", "pr under review",
+      "--json", "number,labels",
+      "--limit", "100",
+    ], config.repoPath);
+
+    const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
+    // Exclude issues also labeled `pr pending actions` — the revise phase owns those.
+    const reviewable = issues.filter((i) => !i.labels.some((l) => l.name === "pr pending actions"));
+    if (reviewable.length === 0) return null;
+
+    // Confirm an open feature PR exists (features → develop).
+    const prJson = gh([
+      "pr", "list",
+      "--repo", config.githubRepo,
+      "--state", "open",
+      "--head", config.featureBranch,
+      "--base", config.baseBranch,
+      "--json", "number,url",
+      "--limit", "1",
+    ], config.repoPath);
+
+    const prs: { number: number; url: string }[] = JSON.parse(prJson || "[]");
+    if (prs.length === 0) {
+      logger.debug(`${config.name}: ${reviewable.length} issue(s) labeled "pr under review" but no open feature PR`);
+      return null;
+    }
+    const pr = prs[0];
+
+    if (hasFreshReview(config, pr.number, reviewerLogin, logger)) {
+      logger.debug(`${config.name}: PR #${pr.number} already has a current ${reviewerLogin} review — skipping re-review`);
+      return null;
+    }
+
+    logger.info(
+      `${config.name}: PR #${pr.number} needs review (issues: ${reviewable.map((i) => `#${i.number}`).join(", ")})`,
+    );
+    return { prNumber: pr.number, prUrl: pr.url, issueNumbers: reviewable.map((i) => i.number) };
+  } catch (err) {
+    logger.error("Failed to check for PRs needing review", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * True when the PR already has an APPROVED/CHANGES_REQUESTED review by
+ * `reviewerLogin` submitted at or after the PR's latest commit (i.e. the current
+ * head has already been reviewed). On any lookup failure returns false — we'd
+ * rather (rarely) re-review than silently never review.
+ */
+function hasFreshReview(
+  config: RepoConfig,
+  prNumber: number,
+  reviewerLogin: string,
+  logger: Logger,
+): boolean {
+  try {
+    const json = gh([
+      "pr", "view", String(prNumber),
+      "--repo", config.githubRepo,
+      "--json", "reviews,commits",
+    ], config.repoPath);
+    const data = JSON.parse(json || "{}") as {
+      commits?: { committedDate?: string }[];
+      reviews?: { author?: { login?: string }; state?: string; submittedAt?: string }[];
+    };
+    const commits = data.commits ?? [];
+    const reviews = data.reviews ?? [];
+    if (commits.length === 0) return false;
+
+    const lastCommitMs = commits
+      .map((c) => (c.committedDate ? new Date(c.committedDate).getTime() : 0))
+      .reduce((a, b) => Math.max(a, b), 0);
+
+    return reviews.some(
+      (r) =>
+        r.author?.login === reviewerLogin &&
+        (r.state === "APPROVED" || r.state === "CHANGES_REQUESTED") &&
+        !!r.submittedAt &&
+        new Date(r.submittedAt).getTime() >= lastCommitMs,
+    );
+  } catch (err) {
+    logger.debug(`hasFreshReview lookup failed for PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 /**
  * Transition issue labels after successful revision:
  * remove "pr pending actions", add "pr under review".

--- a/src/github.ts
+++ b/src/github.ts
@@ -2034,6 +2034,124 @@ export function tryMergeSyncPR(
   }
 }
 
+// --- Dependency PRs (Dependabot) ---
+
+/**
+ * Open Dependabot PRs into `base`, and nothing else.
+ *
+ * Dependabot PRs never carry a linked issue, so the review phase cannot see
+ * them: it is scoped to `features → develop` PRs and every step after the merge
+ * (labelling, follow-up filing, the outcome trailer) is expressed in terms of an
+ * issue. Rather than widen the skill that reviews and merges ALL feature work —
+ * the highest-blast-radius thing here — these get their own mechanical path,
+ * shaped exactly like the `main → develop` sync merge above: a narrow rule, no
+ * agent, no issue.
+ *
+ * **The head-branch test is the safety property, not the label.** Dependabot
+ * labels its PRs `dependencies` by default, but a label is something any account
+ * can apply; `dependabot/*` is a branch only Dependabot writes. Selecting on the
+ * branch means a mislabelled human PR can never be swept into an unreviewed
+ * merge.
+ */
+export function findDependencyPRs(
+  repo: string,
+  cwd: string,
+  base: string,
+  logger?: Logger,
+): PrSnapshot[] {
+  try {
+    return getOpenPrs(repo, cwd).filter(
+      (p) => p.baseRefName === base && p.headRefName.startsWith("dependabot/"),
+    );
+  } catch (err) {
+    logger?.warn("findDependencyPRs: gh pr list failed", { ...formatGhError(err), repo, base });
+    return [];
+  }
+}
+
+/**
+ * Merge one Dependabot PR, but only once every check has CONCLUDED successfully.
+ *
+ * Deliberately stricter than `tryMergeSyncPR`, which merges whatever branch
+ * protection permits. A sync PR carries content that is already on `main` — it
+ * has been reviewed and deployed. A dependency bump has been reviewed by nobody,
+ * so the build and test suite are the entire review, and a merge while they are
+ * still running would be a merge on no evidence at all.
+ *
+ * The gate therefore refuses on ANY check that is not a concluded success:
+ * pending, queued, failed and cancelled all mean "not yet proven". `SKIPPED` and
+ * `NEUTRAL` pass, because a skipped job made no claim either way.
+ *
+ * Returns false and stays quiet on anything unmergeable, so the caller can retry
+ * every cycle without noise — the same idempotent-retry shape as the sync path.
+ */
+export function tryMergeDependencyPR(
+  repo: string,
+  prNumber: number,
+  cwd: string,
+  logger?: Logger,
+): boolean {
+  interface CheckRun { status?: string; conclusion?: string; name?: string }
+  let view: { mergeable?: string; baseRefName?: string; headRefName?: string; statusCheckRollup?: CheckRun[] };
+  try {
+    view = JSON.parse(
+      gh([
+        "pr", "view", String(prNumber),
+        "--repo", repo,
+        "--json", "mergeable,baseRefName,headRefName,statusCheckRollup",
+      ], cwd) || "{}",
+    );
+  } catch (err) {
+    logger?.debug(`Dependency PR #${prNumber}: could not read state: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+
+  // Re-assert both invariants against the PR itself rather than trusting the
+  // list that selected it. A base that is not the development branch is the one
+  // outcome this must never produce.
+  if (!view.headRefName?.startsWith("dependabot/")) {
+    logger?.warn(`Dependency PR #${prNumber} is not a dependabot branch (${view.headRefName}) — refusing`);
+    return false;
+  }
+
+  const checks = view.statusCheckRollup ?? [];
+  const unfinished = checks.filter((c) => (c.status ?? "").toUpperCase() !== "COMPLETED");
+  if (unfinished.length > 0) {
+    logger?.debug(`Dependency PR #${prNumber}: ${unfinished.length} check(s) still running`);
+    return false;
+  }
+  const passing = new Set(["SUCCESS", "SKIPPED", "NEUTRAL"]);
+  const failed = checks.filter((c) => !passing.has((c.conclusion ?? "").toUpperCase()));
+  if (failed.length > 0) {
+    logger?.info(
+      `Dependency PR #${prNumber} has failing check(s): ${failed.map((c) => `${c.name}=${c.conclusion}`).join(", ")} — leaving it open for a human`,
+    );
+    return false;
+  }
+  if (checks.length === 0) {
+    logger?.info(`Dependency PR #${prNumber} has no checks at all — refusing to merge on no evidence`);
+    return false;
+  }
+
+  try {
+    try {
+      ghAsEM([
+        "pr", "review", String(prNumber),
+        "--repo", repo,
+        "--approve",
+        "--body", `Automated dependency update — every check concluded successfully (${checks.length} check(s)). Merged to \`${view.baseRefName}\` by the Foreman; it reaches production only through the normal promotion gate.`,
+      ], cwd);
+    } catch {
+      // Already approved, or approval not required.
+    }
+    ghAsEM(["pr", "merge", String(prNumber), "--repo", repo, "--merge"], cwd);
+    return true;
+  } catch (err) {
+    logger?.debug(`Dependency PR #${prNumber} not mergeable yet: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
 // --- PR Verification ---
 
 export function verifyPRExists(

--- a/src/github.ts
+++ b/src/github.ts
@@ -201,6 +201,19 @@ function invalidateSnapshotIfMutating(args: string[]): void {
   }
 }
 
+/**
+ * Force the next `getOpenIssues(repo)` to hit the network.
+ *
+ * `invalidateSnapshotIfMutating` only sees the Foreman's OWN `gh` calls. The
+ * review phase runs in a SEPARATE Claude process, so every label it writes is
+ * invisible to this cache — read back inside the TTL, an issue the review just
+ * advanced still looks like it never moved. Any check that reads labels a
+ * foreign process may have just written must drop the snapshot first.
+ */
+export function dropIssueSnapshot(repo: string): void {
+  issueSnapshots.delete(repo);
+}
+
 /** Every open issue in the repo, from cache when warm. */
 function getOpenIssues(repo: string, cwd: string, logger: Logger): IssueSnapshot[] {
   const cached = issueSnapshots.get(repo);
@@ -901,15 +914,21 @@ const STUCK_MERGE_GRACE_MS = 15 * 60 * 1000;
  * pinned at `pr under review` with NO phase that ever recovers it. This surfaces
  * those so the EM can re-verify and advance/flag by hand.
  *
- * DETECTION ONLY — never mutates labels. Auto-advancing on a re-verify would risk
- * rubber-stamping a genuine regression (a post-merge FAIL is supposed to HOLD);
- * the safe recovery is to make the stuck state visible, not invisible.
+ * DETECTION ONLY — this function never mutates labels. It does NOT follow that
+ * nothing can be done: re-running the post-merge verification and advancing on
+ * PASS / flagging on FAIL is exactly what the alert asks the EM to do by hand,
+ * and it is not a rubber stamp because the verdict comes from the verifier, not
+ * from the agent that dropped the ball. That repair lives in the orchestrator
+ * (`recoverDeadZonedIssue`); the split keeps "what is broken" separable from
+ * "what we did about it". What remains forbidden is advancing WITHOUT a fresh
+ * verification — a post-merge FAIL must still HOLD.
  *
  * Conservative by design (returns [] on any ambiguity):
  *  - skips main-only repos (no features→develop lifecycle)
  *  - ignores issues also labeled `pr pending actions` (revise owns) or
  *    `ready for prod release` (already advanced)
- *  - ignores repos with an OPEN feature PR (normal review-pending; tryReview owns it)
+ *  - ignores issues REFERENCED BY an open feature PR (normal review-pending;
+ *    tryReview owns those specific issues)
  *  - only flags PRs merged more than STUCK_MERGE_GRACE_MS ago (no flap on fresh merges)
  */
 export function findStuckMergedIssues(
@@ -927,20 +946,50 @@ export function findStuckMergedIssues(
     );
     if (candidates.length === 0) return [];
 
-    // An OPEN feature PR means these are normal review-pending — tryReview owns them.
+    // An open feature PR means the issues THAT PR COVERS are normal
+    // review-pending — tryReview owns those. It says nothing about any other
+    // issue in the repo.
+    //
+    // This used to `return []` for the whole repo the moment any feature PR was
+    // open. Because the feature branch is long-lived and shared, a repo with
+    // active work almost always has one — so a single open PR concealed every
+    // dead-zoned issue behind it, and the dead zone became least visible exactly
+    // when the repo was busiest. Scope the exclusion to the referenced issues.
+    //
+    // Fail CLOSED on an unreadable reference list: if we cannot tell which
+    // issues the open PR covers, suppress the whole repo as before rather than
+    // risk "recovering" an issue whose PR is still open and under review.
     const openFeaturePrs = findOpenPrs(config.githubRepo, config.repoPath, {
       head: config.featureBranch,
       base: config.baseBranch,
       limit: 1,
     });
-    if (openFeaturePrs.length > 0) return [];
+    let reviewPending: number[] = [];
+    if (openFeaturePrs.length > 0) {
+      const referenced = getReferencedIssuesFromOpenPR(
+        config.githubRepo,
+        config.featureBranch,
+        config.baseBranch,
+        config.repoPath,
+        logger,
+      );
+      if (referenced === null) {
+        logger.debug(
+          `${config.name}: open feature PR present but its referenced issues are unreadable — suppressing dead-zone detection this pass`,
+        );
+        return [];
+      }
+      reviewPending = referenced;
+    }
+    const unowned = candidates.filter((i) => !reviewPending.includes(i.number));
+    if (unowned.length === 0) return [];
 
     // Resolve merged work via the SHARED strict primitive — not a bare `#N` scan.
     // A bare-`#N` match would false-positive on an incidental prose mention
     // (slashbin-ai-foreman#28), flagging issues that were never actually merged.
     const merged = findIssuesMergedToBase(
       config,
-      candidates.map((i) => i.number),
+      unowned.map((i) => i.number),
       logger,
     );
 
@@ -953,6 +1002,86 @@ export function findStuckMergedIssues(
       `findStuckMergedIssues failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,
     );
     return [];
+  }
+}
+
+/**
+ * POST-CONDITION CHECK for a finished review run: of `issueNumbers`, which are
+ * still pinned at `pr under review` with no lifecycle label beyond it?
+ *
+ * The review phase reports its own outcome via a self-declared status trailer.
+ * A trailer is a CLAIM; the labels are the STATE. When the two disagree the
+ * labels win, because the next phase reads labels and nothing ever reads the
+ * trailer again. Checking them directly is what makes the orphan detectable
+ * without any cooperation from the agent that created it.
+ *
+ * Reads FRESH — the review runs in a separate process whose label writes never
+ * invalidate our snapshot cache, so a cached read here would report the
+ * pre-review state and manufacture a false orphan on every successful run.
+ *
+ * Returns [] on any lookup failure: a check that cannot see the truth must not
+ * assert one.
+ */
+export function findIssuesStillUnderReview(
+  config: RepoConfig,
+  issueNumbers: number[],
+  logger: Logger,
+): number[] {
+  if (issueNumbers.length === 0) return [];
+  try {
+    dropIssueSnapshot(config.githubRepo);
+    const open = getOpenIssues(config.githubRepo, config.repoPath, logger);
+    return issueNumbers.filter((num) => {
+      const issue = open.find((i) => i.number === num);
+      // Absent from the open set = closed. The review closed it out; not stuck.
+      if (!issue) return false;
+      if (!hasLabel(issue, "pr under review")) return false;
+      return !(
+        hasLabel(issue, "pr approved") ||
+        hasLabel(issue, "pr pending actions") ||
+        hasLabel(issue, "ready for prod release")
+      );
+    });
+  } catch (err) {
+    logger.debug(
+      `findIssuesStillUnderReview failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Move a dead-zoned issue out of `pr under review` once a FRESH verification has
+ * produced a verdict: `pr approved` on PASS, `pr pending actions` on FAIL.
+ *
+ * Deliberately never applies `ready for prod release` — that label is the EM
+ * outcome-gate's signature and stays a human act (separation of duties, same
+ * rule the review prompt enforces). The most this can do is restore the issue to
+ * the state a healthy review run would have left it in.
+ */
+export function resolveDeadZone(
+  config: RepoConfig,
+  issueNumber: number,
+  verdict: "pass" | "fail",
+  logger: Logger,
+): boolean {
+  const nextLabel = verdict === "pass" ? "pr approved" : "pr pending actions";
+  try {
+    gh([
+      "issue", "edit", String(issueNumber),
+      "--repo", config.githubRepo,
+      "--remove-label", "pr under review",
+      "--add-label", nextLabel,
+    ], config.repoPath);
+    logger.info(
+      `Dead-zone resolved on #${issueNumber}: removed "pr under review", added "${nextLabel}" (re-verification ${verdict.toUpperCase()})`,
+    );
+    return true;
+  } catch (err) {
+    logger.warn(
+      `Failed to resolve dead zone on #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
   }
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1250,36 +1250,87 @@ export function transitionReviewOutcomeLabel(
  */
 export const EM_GATE_LABEL = "ready for prod release";
 
+export interface TimelineLabelEvent {
+  event?: string;
+  label?: { name?: string };
+  created_at?: string;
+}
+
 /**
- * Which of `issueNumbers` currently carry the EM outcome-gate label.
+ * Did the EM outcome-gate label get REMOVED at or after `sinceMs`?
  *
- * Taken as a snapshot BEFORE a review run so the same set can be checked after
- * it. `findPRsNeedingReview` already excludes issues that have advanced — but it
- * evaluates that at TRIGGER time, and a review run lasts minutes. An EM gate
- * signed while the run is in flight passes the trigger check and is then
- * overwritten by the run's own label write.
- *
- * Returns [] on any failure, which means "restore nothing" — a lookup that fails
- * must never manufacture a label that was not there.
+ * Pure, so the rule can be tested without a network. The rule that matters is
+ * time-symmetry: this asks "was it taken away during the window", never "did it
+ * exist before the window". The previous guard asked the second question and
+ * therefore missed every gate signed while a review was already running — which
+ * is the normal case, not the edge case.
  */
-export function snapshotEmGate(
-  repo: string,
-  cwd: string,
+export function wasGateRevokedSince(events: TimelineLabelEvent[], sinceMs: number): boolean {
+  return events.some((e) =>
+    e.event === "unlabeled" &&
+    e.label?.name === EM_GATE_LABEL &&
+    typeof e.created_at === "string" &&
+    Number.isFinite(Date.parse(e.created_at)) &&
+    Date.parse(e.created_at) >= sinceMs,
+  );
+}
+
+/**
+ * Which of `issueNumbers` had the EM outcome-gate label REMOVED since `sinceIso`.
+ *
+ * Detected from the issue's own label timeline, not from a snapshot taken before
+ * the run. That distinction is the entire point, and the first version of this
+ * guard got it wrong: it captured which issues held the gate BEFORE the review
+ * started, then restored those. That handles a gate signed before the run and
+ * completely misses a gate signed DURING it — which is the actual reported
+ * scenario, and the one that recurred on Slashbin-io-docs#269 (review triggered
+ * 13:52:25Z, gate signed 13:57:41Z, agent removed it 13:58:20Z, guard restored
+ * nothing because its snapshot predated the signature).
+ *
+ * Reading the timeline is time-symmetric: an `unlabeled` event inside the run
+ * window is a revocation regardless of when the label was applied.
+ *
+ * Only consulted for issues that do NOT currently carry the label, so the healthy
+ * path costs nothing beyond the open-issue snapshot already in hand. Returns []
+ * on any failure — a lookup that fails must never manufacture authorization.
+ */
+export function findRevokedEmGates(
+  config: RepoConfig,
   issueNumbers: number[],
+  sinceIso: string,
   logger: Logger,
 ): number[] {
   if (issueNumbers.length === 0) return [];
+  const since = Date.parse(sinceIso);
+  if (Number.isNaN(since)) return [];
+
+  const revoked: number[] = [];
   try {
-    dropIssueSnapshot(repo);
-    const open = getOpenIssues(repo, cwd, logger);
-    return issueNumbers.filter((num) => {
+    dropIssueSnapshot(config.githubRepo);
+    const open = getOpenIssues(config.githubRepo, config.repoPath, logger);
+
+    for (const num of issueNumbers) {
       const issue = open.find((i) => i.number === num);
-      return issue ? hasLabel(issue, EM_GATE_LABEL) : false;
-    });
+      // Closed, or the gate is still there — nothing was revoked.
+      if (!issue || hasLabel(issue, EM_GATE_LABEL)) continue;
+
+      try {
+        const raw = gh([
+          "api", `repos/${config.githubRepo}/issues/${num}/timeline?per_page=100`,
+          "-H", "Accept: application/vnd.github.mockingbird-preview+json",
+        ], config.repoPath);
+        const events: TimelineLabelEvent[] = JSON.parse(raw || "[]");
+        if (wasGateRevokedSince(events, since)) revoked.push(num);
+      } catch (err) {
+        logger.warn(
+          `Could not read the label timeline for #${num}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   } catch (err) {
-    logger.warn(`snapshotEmGate failed for ${repo}: ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    logger.warn(`findRevokedEmGates failed for ${config.githubRepo}: ${err instanceof Error ? err.message : String(err)}`);
   }
+  return revoked;
 }
 
 export interface EmGateRestoreStep {

--- a/src/github.ts
+++ b/src/github.ts
@@ -194,9 +194,27 @@ export function extractImplementedIssues(opts: {
   body?: string;
   commitHeadlines?: string[];
   commitBodies?: string[];
+  /**
+   * STRICT mode — accept only *closing* keywords (`closes`/`fixes`/`resolves`),
+   * dropping the weak affinity keywords (`related to`, `refs`, `see`).
+   *
+   * Default (false) is the historical predicate, correct for the PR-labeling path
+   * where the consequence is merely ADDING `pr under review` — over-matching there
+   * is cheap and recoverable.
+   *
+   * Strict is required by any TERMINAL transition (one that strips the trigger
+   * label and declares work done), where a false positive permanently marks
+   * unbuilt work as complete. "Related to #N" is not a claim of implementation —
+   * and the Foreman's OWN reconciler writes `- Related to #N` into every recovery
+   * PR body (reconciler.ts), so the loose predicate would terminally close issues
+   * nobody built. That is slashbin-ai-foreman#28's bug with a worse blast radius.
+   */
+  strict?: boolean;
 }): number[] {
-  const { title = "", body = "", commitHeadlines = [], commitBodies = [] } = opts;
-  const keywordRe = /\b(?:related\s+to|closes?|fixes?|resolves?|refs?|see)\s*:?\s*#(\d+)/gi;
+  const { title = "", body = "", commitHeadlines = [], commitBodies = [], strict = false } = opts;
+  const keywordRe = strict
+    ? /\b(?:closes?|fixes?|resolves?)\s*:?\s*#(\d+)/gi
+    : /\b(?:related\s+to|closes?|fixes?|resolves?|refs?|see)\s*:?\s*#(\d+)/gi;
   const suffixRe = /\(#(\d+)\)/g;
   const found = new Set<number>();
 
@@ -579,12 +597,129 @@ function adoptOrphanedReviewCandidate(
   return { prNumber: pr.number, prUrl: pr.url, issueNumbers: adopted };
 }
 
-export interface StuckMergedIssue {
+export interface MergedIssueRef {
   issueNumber: number;
   prNumber: number;
   prUrl: string;
   mergedAt: string;
 }
+
+/**
+ * THE shared primitive: of `candidates`, which issues' work is already MERGED to
+ * `baseBranch`? Resolved by running each recently-merged PR through the STRICT
+ * implemented-issue predicate — a merged PR must say it *closed* the issue
+ * (`closes`/`fixes`/`resolves #N`, or `(#N)` in the title / a commit headline).
+ * A mere "related to #N" does not count. See extractImplementedIssues({strict}).
+ *
+ * Two callers, two DIFFERENT policies — the distinction that matters is
+ * *did a gate reject this work?*:
+ *   - implement-skip (slashbin-ai-foreman#32): no gate ever ran, the work is just
+ *     merged with no lifecycle label → AUTO-ADVANCE to the terminal state.
+ *   - findStuckMergedIssues: post-merge verify FAILED → NEVER auto-advance
+ *     (a gate rejected it); surface to the EM instead.
+ *
+ * Conservative: returns [] on any lookup failure — under-advancing is safe
+ * (status quo), over-advancing marks unbuilt work as done.
+ */
+export function findIssuesMergedToBase(
+  config: RepoConfig,
+  candidates: number[],
+  logger: Logger,
+): MergedIssueRef[] {
+  if (candidates.length === 0) return [];
+  try {
+    const json = gh([
+      "pr", "list",
+      "--repo", config.githubRepo,
+      "--state", "merged",
+      "--base", config.baseBranch,
+      "--json", "number,url,title,body,commits,mergedAt",
+      "--limit", "30",
+    ], config.repoPath);
+    const prs = JSON.parse(json || "[]") as {
+      number: number;
+      url: string;
+      title?: string;
+      body?: string;
+      commits?: { messageHeadline?: string; messageBody?: string }[];
+      mergedAt?: string;
+    }[];
+
+    const wanted = new Set(candidates);
+    const hits = new Map<number, MergedIssueRef>();
+    for (const pr of prs) {
+      const commits = pr.commits ?? [];
+      const closed = extractImplementedIssues({
+        title: pr.title || "",
+        body: pr.body || "",
+        commitHeadlines: commits.map((c) => c.messageHeadline || ""),
+        commitBodies: commits.map((c) => c.messageBody || ""),
+        strict: true,
+      });
+      for (const n of closed) {
+        // Never match a PR against its OWN number: GitHub's squash-merge appends
+        // "(#<pr>)" to the commit headline, which the `(#N)` rule would otherwise
+        // read as "this PR closed issue #<pr>". Harmless today (issues and PRs
+        // share one number sequence, so a PR number is never an issue number) —
+        // guarded anyway so it can't become a real false-advance later.
+        if (n === pr.number) continue;
+        // Keep the FIRST (most recent — gh lists newest-first) merged PR per issue.
+        if (wanted.has(n) && !hits.has(n) && pr.mergedAt) {
+          hits.set(n, {
+            issueNumber: n,
+            prNumber: pr.number,
+            prUrl: pr.url,
+            mergedAt: pr.mergedAt,
+          });
+        }
+      }
+    }
+    return [...hits.values()].sort((a, b) => a.issueNumber - b.issueNumber);
+  } catch (err) {
+    logger.warn("findIssuesMergedToBase: gh pr list failed — advancing nothing", {
+      ...formatGhError(err),
+      repo: config.githubRepo,
+    });
+    return [];
+  }
+}
+
+/**
+ * TERMINAL transition (slashbin-ai-foreman#32): the issue's work is already merged
+ * to the base branch. Strip the trigger label so the issue permanently leaves the
+ * actionable set, and add `ready for prod release` — the EXISTING label meaning
+ * "implemented, awaiting EM prod verification + close."
+ *
+ * Stripping `triggerLabel` is the load-bearing half: without it the issue stays
+ * "actionable" forever and the Foreman burns a full Claude session every back-off
+ * window concluding there is nothing to do. Uses `config.triggerLabel` rather than
+ * a hard-coded "approved" — the trigger label is configurable (OSS).
+ */
+export function transitionToReadyForProd(
+  config: RepoConfig,
+  issueNumbers: number[],
+  logger: Logger,
+): void {
+  for (const num of issueNumbers) {
+    try {
+      gh([
+        "issue", "edit", String(num),
+        "--repo", config.githubRepo,
+        "--remove-label", config.triggerLabel,
+        "--add-label", "ready for prod release",
+      ], config.repoPath);
+      logger.info(
+        `Terminal transition on #${num}: removed "${config.triggerLabel}", added "ready for prod release" (work already merged to ${config.baseBranch})`,
+      );
+    } catch (err) {
+      logger.warn(
+        `Failed terminal transition on #${num}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+export type StuckMergedIssue = MergedIssueRef;
 
 /** Grace window before a merged-but-unadvanced issue is treated as dead-zoned,
  *  giving an in-flight post-merge verify time to advance it. Prevents flapping
@@ -644,39 +779,19 @@ export function findStuckMergedIssues(
     ], config.repoPath);
     if ((JSON.parse(openJson || "[]") as unknown[]).length > 0) return [];
 
-    // Recent merged feature PRs, matched against stuck issues by referenced number.
-    const mergedJson = gh([
-      "pr", "list",
-      "--repo", config.githubRepo,
-      "--state", "merged",
-      "--base", config.baseBranch,
-      "--json", "number,url,title,body,mergedAt",
-      "--limit", "30",
-    ], config.repoPath);
-    const merged: {
-      number: number; url: string; title: string; body: string; mergedAt: string;
-    }[] = JSON.parse(mergedJson || "[]");
+    // Resolve merged work via the SHARED strict primitive — not a bare `#N` scan.
+    // A bare-`#N` match would false-positive on an incidental prose mention
+    // (slashbin-ai-foreman#28), flagging issues that were never actually merged.
+    const merged = findIssuesMergedToBase(
+      config,
+      candidates.map((i) => i.number),
+      logger,
+    );
 
     const nowMs = Date.now();
-    const stuck: StuckMergedIssue[] = [];
-    for (const issue of candidates) {
-      const ref = new RegExp(`#${issue.number}(?!\\d)`);
-      const pr = merged.find(
-        (m) =>
-          (ref.test(m.body || "") || ref.test(m.title || "")) &&
-          !!m.mergedAt &&
-          nowMs - new Date(m.mergedAt).getTime() > STUCK_MERGE_GRACE_MS,
-      );
-      if (pr) {
-        stuck.push({
-          issueNumber: issue.number,
-          prNumber: pr.number,
-          prUrl: pr.url,
-          mergedAt: pr.mergedAt,
-        });
-      }
-    }
-    return stuck;
+    return merged.filter(
+      (m) => nowMs - new Date(m.mergedAt).getTime() > STUCK_MERGE_GRACE_MS,
+    );
   } catch (err) {
     logger.debug(
       `findStuckMergedIssues failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/github.ts
+++ b/src/github.ts
@@ -1051,6 +1051,53 @@ export function findIssuesStillUnderReview(
 }
 
 /**
+ * Move an issue out of `pr under review` into the outcome label its own review
+ * run reported, immediately after that run — the deterministic write that closes
+ * the gap this whole lifecycle used to leave open.
+ *
+ * Why this exists at all: the merge is performed by code, but the record of what
+ * the merge MEANT was left to the review agent to remember to write. Measured over
+ * 7 days (2026-07-29 → 08-04): 53 merges, 12 issues left mislabeled — ~23%. In the
+ * worked example (slashbin-io-worker#575) the agent merged, verified, reported
+ * `verdict=APPROVE merged=yes deploy=SUCCESS`, named the target label 24 times in
+ * its own output, and never executed the write. The Foreman parsed that trailer,
+ * logged it, and did nothing with it.
+ *
+ * Sibling of `resolveDeadZone`, which repairs the same state a cycle later from a
+ * FRESH verification. This one is the first line of defense and needs no
+ * re-verification because the verdict is the one the review just produced. Kept
+ * separate rather than merged with it: the two differ in where their verdict comes
+ * from, and that provenance is exactly what a reader needs to trust either one.
+ *
+ * Never applies `ready for prod release` — that label is the EM outcome-gate's
+ * signature and stays a human act (separation of duties, 2026-07-27).
+ */
+export function transitionReviewOutcomeLabel(
+  config: RepoConfig,
+  issueNumber: number,
+  nextLabel: "pr approved" | "pr pending actions",
+  logger: Logger,
+): boolean {
+  try {
+    gh([
+      "issue", "edit", String(issueNumber),
+      "--repo", config.githubRepo,
+      "--remove-label", "pr under review",
+      "--add-label", nextLabel,
+    ], config.repoPath);
+    logger.info(
+      `Reconciled outcome label on #${issueNumber}: "pr under review" → "${nextLabel}" (from the review run's own trailer)`,
+    );
+    return true;
+  } catch (err) {
+    logger.warn(
+      `Failed to reconcile outcome label on #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
  * Move a dead-zoned issue out of `pr under review` once a FRESH verification has
  * produced a verdict: `pr approved` on PASS, `pr pending actions` on FAIL.
  *

--- a/src/github.ts
+++ b/src/github.ts
@@ -484,6 +484,112 @@ export function findPRsNeedingReview(
   }
 }
 
+export interface StuckMergedIssue {
+  issueNumber: number;
+  prNumber: number;
+  prUrl: string;
+  mergedAt: string;
+}
+
+/** Grace window before a merged-but-unadvanced issue is treated as dead-zoned,
+ *  giving an in-flight post-merge verify time to advance it. Prevents flapping
+ *  on freshly-merged PRs the review agent is still finishing. */
+const STUCK_MERGE_GRACE_MS = 15 * 60 * 1000;
+
+/**
+ * Detect issues DEAD-ZONED by a failed post-merge verify: labeled `pr under
+ * review` with their feature PR already MERGED to the base branch, yet never
+ * advanced to `ready for prod release`. `findPRsNeedingReview` only fires while
+ * the PR is OPEN; once it merges, a failed post-merge verify leaves the issue
+ * pinned at `pr under review` with NO phase that ever recovers it. This surfaces
+ * those so the EM can re-verify and advance/flag by hand.
+ *
+ * DETECTION ONLY — never mutates labels. Auto-advancing on a re-verify would risk
+ * rubber-stamping a genuine regression (a post-merge FAIL is supposed to HOLD);
+ * the safe recovery is to make the stuck state visible, not invisible.
+ *
+ * Conservative by design (returns [] on any ambiguity):
+ *  - skips main-only repos (no features→develop lifecycle)
+ *  - ignores issues also labeled `pr pending actions` (revise owns) or
+ *    `ready for prod release` (already advanced)
+ *  - ignores repos with an OPEN feature PR (normal review-pending; tryReview owns it)
+ *  - only flags PRs merged more than STUCK_MERGE_GRACE_MS ago (no flap on fresh merges)
+ */
+export function findStuckMergedIssues(
+  config: RepoConfig,
+  logger: Logger,
+): StuckMergedIssue[] {
+  if (config.baseBranch === config.featureBranch) return [];
+  try {
+    const issueJson = gh([
+      "issue", "list",
+      "--repo", config.githubRepo,
+      "--state", "open",
+      "--label", "pr under review",
+      "--json", "number,labels",
+      "--limit", "100",
+    ], config.repoPath);
+    const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
+    const candidates = issues.filter(
+      (i) => !i.labels.some(
+        (l) => l.name === "pr pending actions" || l.name === "ready for prod release",
+      ),
+    );
+    if (candidates.length === 0) return [];
+
+    // An OPEN feature PR means these are normal review-pending — tryReview owns them.
+    const openJson = gh([
+      "pr", "list",
+      "--repo", config.githubRepo,
+      "--state", "open",
+      "--head", config.featureBranch,
+      "--base", config.baseBranch,
+      "--json", "number",
+      "--limit", "1",
+    ], config.repoPath);
+    if ((JSON.parse(openJson || "[]") as unknown[]).length > 0) return [];
+
+    // Recent merged feature PRs, matched against stuck issues by referenced number.
+    const mergedJson = gh([
+      "pr", "list",
+      "--repo", config.githubRepo,
+      "--state", "merged",
+      "--base", config.baseBranch,
+      "--json", "number,url,title,body,mergedAt",
+      "--limit", "30",
+    ], config.repoPath);
+    const merged: {
+      number: number; url: string; title: string; body: string; mergedAt: string;
+    }[] = JSON.parse(mergedJson || "[]");
+
+    const nowMs = Date.now();
+    const stuck: StuckMergedIssue[] = [];
+    for (const issue of candidates) {
+      const ref = new RegExp(`#${issue.number}(?!\\d)`);
+      const pr = merged.find(
+        (m) =>
+          (ref.test(m.body || "") || ref.test(m.title || "")) &&
+          !!m.mergedAt &&
+          nowMs - new Date(m.mergedAt).getTime() > STUCK_MERGE_GRACE_MS,
+      );
+      if (pr) {
+        stuck.push({
+          issueNumber: issue.number,
+          prNumber: pr.number,
+          prUrl: pr.url,
+          mergedAt: pr.mergedAt,
+        });
+      }
+    }
+    return stuck;
+  } catch (err) {
+    logger.debug(
+      `findStuckMergedIssues failed for ${config.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return [];
+  }
+}
+
 /**
  * True when the PR already has an APPROVED/CHANGES_REQUESTED review by
  * `reviewerLogin` submitted at or after the PR's latest commit (i.e. the current

--- a/src/github.ts
+++ b/src/github.ts
@@ -10,30 +10,75 @@ interface GhIssue {
   url: string;
 }
 
+const GH_MAX_ATTEMPTS = 3;
+const GH_BACKOFF_MS = [1000, 3000, 9000];
+
+/** Block the thread for `ms` without busy-waiting. Only hit on the rare retry
+ *  path; keeps the gh() wrapper synchronous so no caller signature changes. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, ms));
+}
+
+/**
+ * A gh failure is *transient* (safe to retry) only when it's network/connectivity
+ * or a server-side 5xx/timeout — NOT auth, 404, or 422 validation, which won't
+ * improve on retry (those fall through to an immediate throw). Allowlist by design.
+ * A host↔GitHub blip ("error connecting to api.github.com") was stalling the whole
+ * fleet ("No work across all repos"); retrying absorbs it instead of erroring the cycle.
+ */
+function isTransientGhError(err: unknown): boolean {
+  const { message, stderr } = formatGhError(err);
+  const blob = `${message}\n${stderr}`.toLowerCase();
+  return (
+    blob.includes("error connecting to api.github.com") ||
+    blob.includes("timed out") || blob.includes("timeout") ||
+    blob.includes("etimedout") || blob.includes("econnreset") ||
+    blob.includes("enotfound") || blob.includes("eai_again") ||
+    blob.includes("dial tcp") ||
+    blob.includes("bad gateway") || blob.includes("service unavailable") ||
+    blob.includes("http 502") || blob.includes("http 503") || blob.includes("http 504")
+  );
+}
+
+/** execFileSync gh with retry+backoff on transient (network/5xx/timeout) failures. */
+function runGh(args: string[], cwd: string, token: string): string {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= GH_MAX_ATTEMPTS; attempt++) {
+    try {
+      return execFileSync("gh", args, {
+        cwd,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 30_000,
+        env: { ...process.env, GH_TOKEN: token },
+      }).trim();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < GH_MAX_ATTEMPTS && isTransientGhError(err)) {
+        const wait = GH_BACKOFF_MS[attempt - 1];
+        const { message, stderr } = formatGhError(err);
+        console.warn(`[gh] transient failure (attempt ${attempt}/${GH_MAX_ATTEMPTS}), retrying in ${wait}ms: ${stderr.split("\n")[0] || message}`);
+        sleepSync(wait);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}
+
 /** Run gh CLI using the Foreman token (slashbin-foreman account). */
 export function gh(args: string[], cwd: string): string {
   const foremanToken = process.env.FOREMAN_GITHUB_TOKEN;
   if (!foremanToken) throw new Error("FOREMAN_GITHUB_TOKEN not set — cannot operate as Foreman");
-  return execFileSync("gh", args, {
-    cwd,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    timeout: 30_000,
-    env: { ...process.env, GH_TOKEN: foremanToken },
-  }).trim();
+  return runGh(args, cwd, foremanToken);
 }
 
 /** Run gh CLI using the EM token (slashbin-engineering-manager account). */
 function ghAsEM(args: string[], cwd: string): string {
   const emToken = process.env.EM_GITHUB_TOKEN;
   if (!emToken) throw new Error("EM_GITHUB_TOKEN not set — cannot approve/merge as EM");
-  return execFileSync("gh", args, {
-    cwd,
-    encoding: "utf-8",
-    stdio: ["pipe", "pipe", "pipe"],
-    timeout: 30_000,
-    env: { ...process.env, GH_TOKEN: emToken },
-  }).trim();
+  return runGh(args, cwd, emToken);
 }
 
 /**

--- a/src/github.ts
+++ b/src/github.ts
@@ -1098,6 +1098,139 @@ export function transitionReviewOutcomeLabel(
 }
 
 /**
+ * The label that authorizes production. Only the EM outcome-gate applies it, and
+ * nothing in the review path may take it away.
+ */
+export const EM_GATE_LABEL = "ready for prod release";
+
+/**
+ * Which of `issueNumbers` currently carry the EM outcome-gate label.
+ *
+ * Taken as a snapshot BEFORE a review run so the same set can be checked after
+ * it. `findPRsNeedingReview` already excludes issues that have advanced — but it
+ * evaluates that at TRIGGER time, and a review run lasts minutes. An EM gate
+ * signed while the run is in flight passes the trigger check and is then
+ * overwritten by the run's own label write.
+ *
+ * Returns [] on any failure, which means "restore nothing" — a lookup that fails
+ * must never manufacture a label that was not there.
+ */
+export function snapshotEmGate(
+  repo: string,
+  cwd: string,
+  issueNumbers: number[],
+  logger: Logger,
+): number[] {
+  if (issueNumbers.length === 0) return [];
+  try {
+    dropIssueSnapshot(repo);
+    const open = getOpenIssues(repo, cwd, logger);
+    return issueNumbers.filter((num) => {
+      const issue = open.find((i) => i.number === num);
+      return issue ? hasLabel(issue, EM_GATE_LABEL) : false;
+    });
+  } catch (err) {
+    logger.warn(`snapshotEmGate failed for ${repo}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+export interface EmGateRestoreStep {
+  number: number;
+  /** The review wrote `pr approved` in the gate's place — strip it on the way back. */
+  dropPrApproved: boolean;
+}
+
+/**
+ * Decide, with no I/O, which issues need their EM outcome-gate put back.
+ *
+ * Split out from `restoreEmGate` so the decision is testable without a network:
+ * the rules about what counts as "revoked" are the part worth pinning, and the
+ * `gh` call around them is not.
+ *
+ * Restores only issues that (a) carried the gate before the run, (b) are still
+ * open, and (c) no longer carry it. A closed issue needs no gate — the promotion
+ * either happened or the work was abandoned, and re-labeling a closed issue would
+ * put it back in the Foreman's pickup list for no reason.
+ */
+export function planEmGateRestore(
+  hadGate: number[],
+  open: { number: number; labels: { name: string }[] }[],
+): EmGateRestoreStep[] {
+  const steps: EmGateRestoreStep[] = [];
+  for (const num of hadGate) {
+    const issue = open.find((i) => i.number === num);
+    if (!issue) continue;                                   // closed — nothing to restore
+    const names = new Set(issue.labels.map((l) => l.name));
+    if (names.has(EM_GATE_LABEL)) continue;                 // still signed — healthy path
+    steps.push({ number: num, dropPrApproved: names.has("pr approved") });
+  }
+  return steps;
+}
+
+/**
+ * Put back any EM outcome-gate label that disappeared across a review run.
+ *
+ * The review agent writes issue labels itself, so the Foreman cannot intercept
+ * that write — it can only detect the damage and undo it. This is the structural
+ * half of a rule that until now existed only as a sentence in the review prompt.
+ *
+ * Why it matters that this is silent without the check: `tryPromotion` calls
+ * `findReadyForProdIssues`, which filters on exactly this label, and returns
+ * early on an empty set. A revoked gate produces no PR, no error and no log line
+ * — indistinguishable from having nothing to promote. Observed on
+ * Slashbin-io-docs, 2026-08-04: the gate was signed at 20:20:15Z, overwritten
+ * with `pr approved` at 20:22:12Z by a review run that started at 20:11:59Z, and
+ * the promotion sat stalled for an hour until a human noticed the absence.
+ *
+ * A review verdict is never authority to revoke production authorization, so
+ * restoring is unconditional. `pr approved` is stripped only when present — it is
+ * the label the review wrote in the gate's place, and the two are different
+ * lifecycle states, not additive ones.
+ *
+ * Returns the issues actually restored (usually none — the healthy path).
+ */
+export function restoreEmGate(
+  config: RepoConfig,
+  hadGate: number[],
+  logger: Logger,
+): number[] {
+  if (hadGate.length === 0) return [];
+  const restored: number[] = [];
+  try {
+    dropIssueSnapshot(config.githubRepo);
+    const open = getOpenIssues(config.githubRepo, config.repoPath, logger);
+    for (const step of planEmGateRestore(hadGate, open)) {
+      const { number: num, dropPrApproved } = step;
+      const args = [
+        "issue", "edit", String(num),
+        "--repo", config.githubRepo,
+        "--add-label", EM_GATE_LABEL,
+      ];
+      // Only remove what is actually there; `gh` errors on removing an absent label.
+      if (dropPrApproved) args.push("--remove-label", "pr approved");
+
+      try {
+        gh(args, config.repoPath);
+        restored.push(num);
+        logger.warn(
+          `Restored "${EM_GATE_LABEL}" on #${num} — the review run removed it. ` +
+          `A review verdict does not authorize or revoke production; only the EM outcome-gate does.`,
+        );
+      } catch (err) {
+        logger.error(
+          `Failed to restore "${EM_GATE_LABEL}" on #${num} — promotion is STALLED until a human re-applies it: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  } catch (err) {
+    logger.warn(`restoreEmGate failed for ${config.githubRepo}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return restored;
+}
+
+/**
  * Move a dead-zoned issue out of `pr under review` once a FRESH verification has
  * produced a verdict: `pr approved` on PASS, `pr pending actions` on FAIL.
  *

--- a/src/github.ts
+++ b/src/github.ts
@@ -687,8 +687,12 @@ export function findIssuesMergedToBase(
 /**
  * TERMINAL transition (slashbin-ai-foreman#32): the issue's work is already merged
  * to the base branch. Strip the trigger label so the issue permanently leaves the
- * actionable set, and add `ready for prod release` — the EXISTING label meaning
- * "implemented, awaiting EM prod verification + close."
+ * actionable set, and add `pr approved` — meaning "implemented and merged, awaiting
+ * the EM outcome-gate."
+ *
+ * It must NOT be `ready for prod release`: that label is the EM outcome-gate's
+ * signature and authorizes production. Granting it here would let the Foreman
+ * authorize its own release (separation of duties, 2026-07-27).
  *
  * Stripping `triggerLabel` is the load-bearing half: without it the issue stays
  * "actionable" forever and the Foreman burns a full Claude session every back-off
@@ -706,10 +710,10 @@ export function transitionToReadyForProd(
         "issue", "edit", String(num),
         "--repo", config.githubRepo,
         "--remove-label", config.triggerLabel,
-        "--add-label", "ready for prod release",
+        "--add-label", "pr approved",
       ], config.repoPath);
       logger.info(
-        `Terminal transition on #${num}: removed "${config.triggerLabel}", added "ready for prod release" (work already merged to ${config.baseBranch})`,
+        `Terminal transition on #${num}: removed "${config.triggerLabel}", added "pr approved" (work already merged to ${config.baseBranch})`,
       );
     } catch (err) {
       logger.warn(
@@ -762,7 +766,7 @@ export function findStuckMergedIssues(
     const issues: { number: number; labels: { name: string }[] }[] = JSON.parse(issueJson || "[]");
     const candidates = issues.filter(
       (i) => !i.labels.some(
-        (l) => l.name === "pr pending actions" || l.name === "ready for prod release",
+        (l) => l.name === "pr pending actions" || l.name === "pr approved" || l.name === "ready for prod release",
       ),
     );
     if (candidates.length === 0) return [];

--- a/src/github.ts
+++ b/src/github.ts
@@ -1424,15 +1424,73 @@ export function createSyncPR(
 
       logger?.info(`Sync PR #${prNumber} created and merged immediately`);
     } catch (mergeErr) {
-      // If merge fails (status checks, conflicts), log but don't crash.
-      // The PR still exists for manual merge.
-      logger?.warn(`Sync PR #${prNumber} created but auto-merge failed: ${mergeErr instanceof Error ? mergeErr.message : String(mergeErr)}`);
+      // Expected on any repo with required status checks: the merge is attempted
+      // seconds after creation, while build/test/typecheck are still IN_PROGRESS,
+      // so branch protection refuses it. Not fatal — `tryMergeSyncPR` retries on a
+      // later cycle once the checks land. See its comment for why that retry is
+      // load-bearing rather than cosmetic.
+      logger?.warn(`Sync PR #${prNumber} created but immediate auto-merge failed (will retry next cycle): ${mergeErr instanceof Error ? mergeErr.message : String(mergeErr)}`);
     }
 
     return prUrl;
   } catch (err) {
     logger?.warn("createSyncPR: gh pr create failed", { ...formatGhError(err), repo, behindBy });
     return null;
+  }
+}
+
+/**
+ * Merge an already-open sync PR. Returns true only if it is merged afterwards.
+ *
+ * WHY THIS EXISTS (2026-07-30). `createSyncPR` approves and merges the instant it
+ * creates the PR — seconds later, while required status checks are still
+ * IN_PROGRESS. On any repo with branch protection that merge is refused. The old
+ * code caught that, said "the PR still exists for manual merge", and moved on;
+ * the caller then logged "Sync PR created and auto-merged" regardless, and on
+ * every later cycle logged "Sync PR already open" and returned early WITHOUT ever
+ * retrying. So the merge never happened, the log claimed it had, and the sync PR
+ * stayed open forever.
+ *
+ * That is not cosmetic. `develop` stays behind `main`, which makes the next
+ * promotion PR `BEHIND`, which branch protection refuses to merge. Observed on
+ * `Slashbin-console#779`: open 2h48m across ~140 no-op cycles, blocking the
+ * promotion of #782 until it was merged by hand. The same "created and
+ * auto-merged" line had already been logged for #438, #559 and #783.
+ *
+ * Idempotent by construction: re-approving an approved PR and merging a merged
+ * PR are both no-ops we treat as success, so retrying every cycle is safe.
+ */
+export function tryMergeSyncPR(
+  repo: string,
+  prNumber: number,
+  cwd: string,
+  logger?: Logger,
+): boolean {
+  try {
+    // Re-approve defensively: on the retry path the original approval is already
+    // there, and gh treats a repeat approval as a no-op.
+    try {
+      ghAsEM([
+        "pr", "review", String(prNumber),
+        "--repo", repo,
+        "--approve",
+        "--body", "Automated sync — approved by EM.",
+      ], cwd);
+    } catch {
+      // Already approved, or approval not required. Not a reason to skip the merge.
+    }
+
+    ghAsEM([
+      "pr", "merge", String(prNumber),
+      "--repo", repo,
+      "--merge",
+    ], cwd);
+    return true;
+  } catch (err) {
+    // Still blocked (checks pending, conflict, protection). Report at debug so a
+    // normal cycle isn't noisy — the caller reports the durable state.
+    logger?.debug(`Sync PR #${prNumber} not mergeable yet: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
   }
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -163,6 +163,7 @@ export function configureIssueCache(opts: { ttlMs?: number; snapshotLimit?: numb
     issueSnapshotLimit = Math.floor(opts.snapshotLimit);
   }
   issueSnapshots.clear();
+  prSnapshots.clear();
 }
 
 /**
@@ -171,11 +172,33 @@ export function configureIssueCache(opts: { ttlMs?: number; snapshotLimit?: numb
  * `list`/`view` are reads and left alone.
  */
 function invalidateSnapshotIfMutating(args: string[]): void {
-  if (args[0] !== "issue") return;
-  if (args[1] === "list" || args[1] === "view") return;
-  const i = args.indexOf("--repo");
-  const repo = i >= 0 ? args[i + 1] : undefined;
-  if (repo) issueSnapshots.delete(repo);
+  const repoIdx = args.indexOf("--repo");
+  const repo = repoIdx >= 0 ? args[repoIdx + 1] : undefined;
+
+  // `gh api --method POST/PATCH/PUT/DELETE` can label, merge, or retarget
+  // anything, and the URL shape varies too much to attribute reliably. Clear
+  // everything — conservative, and a cache miss only costs one request.
+  const methodIdx = args.indexOf("--method");
+  if (args[0] === "api" && methodIdx >= 0 && args[methodIdx + 1] !== "GET") {
+    issueSnapshots.clear();
+    prSnapshots.clear();
+    return;
+  }
+
+  if (!repo) return;
+
+  // Read-only subcommands leave state alone; everything else may change it.
+  const READ_ONLY = new Set(["list", "view", "diff", "checks", "status"]);
+  if (READ_ONLY.has(args[1])) return;
+
+  if (args[0] === "issue") issueSnapshots.delete(repo);
+  // A PR merge closes the PR *and* moves the issue labels that track it, so a
+  // `pr` mutation has to drop both — otherwise a later phase this cycle reads a
+  // merged PR back as open.
+  if (args[0] === "pr") {
+    prSnapshots.delete(repo);
+    issueSnapshots.delete(repo);
+  }
 }
 
 /** Every open issue in the repo, from cache when warm. */
@@ -210,6 +233,73 @@ function getOpenIssues(repo: string, cwd: string, logger: Logger): IssueSnapshot
 /** True when `issue` carries a label named `name`. */
 function hasLabel(issue: IssueSnapshot, name: string): boolean {
   return issue.labels.some((l) => l.name === name);
+}
+
+/**
+ * The same collapse for OPEN pull requests, and for the same reason.
+ *
+ * Roughly three `gh pr list --state open` calls run per repo per cycle no matter
+ * whether there is any work — the reconcile phase's sync-PR check
+ * (`develop ← main`), the promote phase's open-promotion-PR check
+ * (`main ← develop`), and the review phase's orphan-adoption probe, which runs
+ * precisely when there is nothing to review, i.e. most cycles. Each spends a
+ * GraphQL request. At 20 repos on a 60s interval that is ~3,600/hour on its own,
+ * and it is why collapsing the issue lookups alone left the token at 5,279/hour
+ * against a 5,000 ceiling — measured, after that first fix.
+ *
+ * Every one of those calls is a `--head`/`--base` slice of "open PRs in this
+ * repo", so they share one snapshot and filter in memory.
+ *
+ * Deliberately NOT served from here: `--state merged` queries (a different set)
+ * and the one call that needs `files` (a per-PR file list, far heavier than the
+ * scalar fields below). Those stay live.
+ */
+interface PrSnapshot {
+  number: number;
+  url: string;
+  title: string;
+  body: string;
+  headRefName: string;
+  baseRefName: string;
+}
+
+const prSnapshots = new Map<string, { fetchedAt: number; prs: PrSnapshot[] }>();
+
+/** Every open PR in the repo, from cache when warm. */
+function getOpenPrs(repo: string, cwd: string): PrSnapshot[] {
+  const cached = prSnapshots.get(repo);
+  if (cached && issueCacheTtlMs > 0 && Date.now() - cached.fetchedAt < issueCacheTtlMs) {
+    return cached.prs;
+  }
+
+  const json = gh([
+    "pr", "list",
+    "--repo", repo,
+    "--state", "open",
+    "--json", "number,url,title,body,headRefName,baseRefName",
+    "--limit", "100",
+  ], cwd);
+  const prs: PrSnapshot[] = JSON.parse(json || "[]");
+
+  if (issueCacheTtlMs > 0) prSnapshots.set(repo, { fetchedAt: Date.now(), prs });
+  return prs;
+}
+
+/**
+ * Open PRs matching a head/base pair, newest first — the shape the old
+ * `--head X --base Y --limit N` calls returned.
+ */
+function findOpenPrs(
+  repo: string,
+  cwd: string,
+  opts: { head?: string; base?: string; limit?: number },
+): PrSnapshot[] {
+  const matches = getOpenPrs(repo, cwd).filter(
+    (p) =>
+      (opts.head === undefined || p.headRefName === opts.head) &&
+      (opts.base === undefined || p.baseRefName === opts.base),
+  );
+  return opts.limit === undefined ? matches : matches.slice(0, opts.limit);
 }
 
 /**
@@ -391,14 +481,7 @@ export function findActionableIssues(
     // that references them. If so, skip — the Foreman already did the work.
     // Check both open and merged PRs to catch issues where the PR was already merged
     // but the issue label wasn't updated.
-    const openPrJson = gh([
-      "pr", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--base", config.baseBranch,
-      "--json", "number,title,body",
-      "--limit", "50",
-    ], config.repoPath);
+    const openPrs = findOpenPrs(repo, config.repoPath, { base: config.baseBranch, limit: 50 });
 
     const mergedPrJson = gh([
       "pr", "list",
@@ -409,7 +492,6 @@ export function findActionableIssues(
       "--limit", "20",
     ], config.repoPath);
 
-    const openPrs: { number: number; title: string; body: string }[] = JSON.parse(openPrJson || "[]");
     const mergedPrs: { number: number; title: string; body: string }[] = JSON.parse(mergedPrJson || "[]");
     const allPrs = [...openPrs, ...mergedPrs];
 
@@ -500,17 +582,11 @@ export function findPendingRevisions(
     if (issues.length === 0) return null;
 
     // Confirm there's an open feature PR (features → develop)
-    const prJson = gh([
-      "pr", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--head", config.featureBranch,
-      "--base", config.baseBranch,
-      "--json", "number,url,headRefName",
-      "--limit", "1",
-    ], config.repoPath);
-
-    const prs: PendingRevisionPR[] = JSON.parse(prJson || "[]");
+    const prs: PendingRevisionPR[] = findOpenPrs(config.githubRepo, config.repoPath, {
+      head: config.featureBranch,
+      base: config.baseBranch,
+      limit: 1,
+    });
     if (prs.length > 0) {
       logger.info(`Found ${issues.length} issue(s) pending revision with open PR #${prs[0].number}: ${issues.map(i => `#${i.number}`).join(", ")}`);
       return { issueNumbers: issues.map(i => i.number), pr: prs[0] };
@@ -578,17 +654,11 @@ export function findPRsNeedingReview(
     }
 
     // Confirm an open feature PR exists (features → develop).
-    const prJson = gh([
-      "pr", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--head", config.featureBranch,
-      "--base", config.baseBranch,
-      "--json", "number,url",
-      "--limit", "1",
-    ], config.repoPath);
-
-    const prs: { number: number; url: string }[] = JSON.parse(prJson || "[]");
+    const prs: { number: number; url: string }[] = findOpenPrs(config.githubRepo, config.repoPath, {
+      head: config.featureBranch,
+      base: config.baseBranch,
+      limit: 1,
+    });
     if (prs.length === 0) {
       logger.debug(`${config.name}: ${reviewable.length} issue(s) labeled "pr under review" but no open feature PR`);
       return null;
@@ -631,17 +701,11 @@ function adoptOrphanedReviewCandidate(
   reviewerLogin: string,
   logger: Logger,
 ): ReviewCandidate | null {
-  const prJson = gh([
-    "pr", "list",
-    "--repo", config.githubRepo,
-    "--state", "open",
-    "--head", config.featureBranch,
-    "--base", config.baseBranch,
-    "--json", "number,url,title,body",
-    "--limit", "1",
-  ], config.repoPath);
-
-  const prs: { number: number; url: string; title: string; body: string }[] = JSON.parse(prJson || "[]");
+  const prs: { number: number; url: string; title: string; body: string }[] = findOpenPrs(
+    config.githubRepo,
+    config.repoPath,
+    { head: config.featureBranch, base: config.baseBranch, limit: 1 },
+  );
   if (prs.length === 0) return null;
   const pr = prs[0];
 
@@ -864,16 +928,12 @@ export function findStuckMergedIssues(
     if (candidates.length === 0) return [];
 
     // An OPEN feature PR means these are normal review-pending — tryReview owns them.
-    const openJson = gh([
-      "pr", "list",
-      "--repo", config.githubRepo,
-      "--state", "open",
-      "--head", config.featureBranch,
-      "--base", config.baseBranch,
-      "--json", "number",
-      "--limit", "1",
-    ], config.repoPath);
-    if ((JSON.parse(openJson || "[]") as unknown[]).length > 0) return [];
+    const openFeaturePrs = findOpenPrs(config.githubRepo, config.repoPath, {
+      head: config.featureBranch,
+      base: config.baseBranch,
+      limit: 1,
+    });
+    if (openFeaturePrs.length > 0) return [];
 
     // Resolve merged work via the SHARED strict primitive — not a bare `#N` scan.
     // A bare-`#N` match would false-positive on an incidental prose mention
@@ -1025,17 +1085,7 @@ export function findOpenPromotionPR(
   logger?: Logger,
 ): OpenPromotionPR | null {
   try {
-    const json = gh([
-      "pr", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--base", baseBranch,
-      "--head", "develop",
-      "--json", "number,url,body",
-      "--limit", "1",
-    ], cwd);
-
-    const prs: OpenPromotionPR[] = JSON.parse(json || "[]");
+    const prs: OpenPromotionPR[] = findOpenPrs(repo, cwd, { base: baseBranch, head: "develop", limit: 1 });
     return prs.length > 0 ? prs[0] : null;
   } catch (err) {
     logger?.warn("findOpenPromotionPR: gh pr list failed", { ...formatGhError(err) });
@@ -1313,17 +1363,7 @@ export function findOpenSyncPR(
   logger?: Logger,
 ): OpenPromotionPR | null {
   try {
-    const json = gh([
-      "pr", "list",
-      "--repo", repo,
-      "--state", "open",
-      "--base", "develop",
-      "--head", "main",
-      "--json", "number,url",
-      "--limit", "1",
-    ], cwd);
-
-    const prs: OpenPromotionPR[] = JSON.parse(json || "[]");
+    const prs: OpenPromotionPR[] = findOpenPrs(repo, cwd, { base: "develop", head: "main", limit: 1 });
     return prs.length > 0 ? prs[0] : null;
   } catch (err) {
     logger?.warn("findOpenSyncPR: gh pr list failed", { ...formatGhError(err) });
@@ -1406,16 +1446,7 @@ export function verifyPRExists(
   logger?: Logger,
 ): boolean {
   try {
-    const json = gh([
-      "pr", "list",
-      "--repo", repo,
-      "--head", headBranch,
-      "--base", baseBranch,
-      "--state", "open",
-      "--json", "number",
-      "--limit", "1",
-    ], cwd);
-    const prs = JSON.parse(json || "[]");
+    const prs = findOpenPrs(repo, cwd, { head: headBranch, base: baseBranch, limit: 1 });
     return prs.length > 0;
   } catch (err) {
     logger?.warn("verifyPRExists: gh pr list failed", { ...formatGhError(err), repo, headBranch, baseBranch });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -58,6 +58,12 @@ const activeRuns = new Map<string, AbortController>();
 const failureCount = new Map<string, number>();
 const failureHitMaxAt = new Map<string, number>(); // cycle when max was hit
 const revisionFailureCount = new Map<string, number>();
+// Repos whose revision retries are exhausted AND already escalated. Without this
+// the cap was reached silently: the count hit MAX_RETRIES, every later cycle took
+// the `debug` skip branch, and the stuck PR sat there with nobody told. The set is
+// cleared the moment a revision succeeds or the pending feedback clears, so a repo
+// that recovers escalates again if it breaks again.
+const revisionEscalated = new Set<string>();
 const reviewFailureCount = new Map<string, number>();
 const reviewFailureHitMaxAt = new Map<string, number>();
 
@@ -626,7 +632,7 @@ async function runRepoCycle(
   if (await tryReview(repoConfig, config, base, cycleNumber, events)) processed++;
 
   // --- Phase 2: Revise PRs with pending review feedback ---
-  const revisionInfo = await tryRevision(repoConfig, base, cycleNumber);
+  const revisionInfo = await tryRevision(repoConfig, base, cycleNumber, events);
   if (revisionInfo) {
     events.push({ message: `Revised ${repoConfig.githubRepo} PR #${revisionInfo.pr.number} (issues: ${revisionInfo.issueNumbers.map(n => `#${n}`).join(", ")})`, level: "info" });
     processed++;
@@ -1127,7 +1133,8 @@ async function tryBatchImplementation(
 async function tryRevision(
   repoConfig: RepoConfig,
   logger: Logger,
-  cycleNumber: number
+  cycleNumber: number,
+  events: CycleEvent[],
 ): Promise<PendingRevisionInfo | null> {
   const repoName = repoConfig.name;
   const revLogger = logger.child({ cycle: cycleNumber, repo: repoName, phase: "revision" });
@@ -1143,6 +1150,7 @@ async function tryRevision(
   const pending = findPendingRevisions(repoConfig, revLogger);
   if (!pending) {
     if (failures > 0) revisionFailureCount.set(repoName, 0);
+    revisionEscalated.delete(repoName);
     return null;
   }
 
@@ -1159,6 +1167,7 @@ async function tryRevision(
 
     if (result.success) {
       revisionFailureCount.set(repoName, 0);
+      revisionEscalated.delete(repoName);
 
       // Transition issue labels: "pr pending actions" → "pr under review"
       // The orchestrator owns this because the skill runs in the service repo
@@ -1176,6 +1185,26 @@ async function tryRevision(
       const newCount = failures + 1;
       revisionFailureCount.set(repoName, newCount);
       revLogger.warn(`PR revision failed (${newCount}/${MAX_RETRIES}): ${result.error}`);
+
+      // Retries exhausted. This is the end of the automated road for this PR: every
+      // later cycle takes the skip branch above and does nothing. Say so out loud,
+      // once, with the PR and the reason — a stuck PR that nobody is told about is
+      // only discovered by someone thinking to look.
+      if (newCount >= MAX_RETRIES && !revisionEscalated.has(repoName)) {
+        revisionEscalated.add(repoName);
+        const issues = pending.issueNumbers.map((n) => `#${n}`).join(", ");
+        revLogger.error(
+          `Revision retries exhausted on PR #${pending.pr.number} — no further attempts will be made ` +
+          `until the feedback clears or a revision succeeds.`,
+          { pr: pending.pr.number, issues: pending.issueNumbers, lastError: result.error },
+        );
+        events.push({
+          message:
+            `🛑 ${repoConfig.githubRepo} — PR #${pending.pr.number} failed revision ${newCount}x and the Foreman has ` +
+            `STOPPED retrying it${issues ? ` (issues ${issues})` : ""}. It needs a human. Last failure: ${result.error ?? "unknown"}`,
+          level: "error",
+        });
+      }
     }
 
     return null;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -23,7 +23,7 @@ import {
 } from "./github.js";
 import { implementApprovedIssues, revisePRFeedback, reviewOpenPRs, type ImplementationResult, type RevisionResult } from "./agent.js";
 import { reconcileRepo, checkLocalBranchDivergence } from "./reconciler.js";
-import { verifyPRExists } from "./github.js";
+import { verifyPRExists, findStuckMergedIssues } from "./github.js";
 import { loadRepoState, saveRepoState } from "./state.js";
 
 const MAX_RETRIES = 2;
@@ -100,6 +100,27 @@ export async function runCycle(
       reconLogger.error("Reconciliation failed", {
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+
+    // Surface dead-zoned issues: PR merged to develop but the issue is still
+    // `pr under review` (post-merge verify failed and no phase recovers it).
+    // Detection only — the EM re-verifies and advances/flags by hand.
+    try {
+      const stuck = findStuckMergedIssues(repoConfig, reconLogger);
+      for (const s of stuck) {
+        reconLogger.warn(
+          `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it`,
+          { prUrl: s.prUrl, mergedAt: s.mergedAt },
+        );
+        events.push({
+          message: `⚠️ ${repoConfig.githubRepo} #${s.issueNumber} dead-zoned: PR #${s.prNumber} merged but issue still "pr under review". EM: re-verify (npm run verify --repo ${repoConfig.name} --pr ${s.prNumber} --env development), then advance to "ready for prod release" or flag "pr pending actions".`,
+          level: "warn",
+        });
+      }
+    } catch (err) {
+      reconLogger.debug(
+        `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -118,10 +118,75 @@ export interface CycleResult {
  *  `repoCycle` (this service's own pass count). */
 const repoCycleCounter = new Map<string, number>();
 
-interface RepoCycleResult {
+export interface RepoCycleResult {
   processed: number;
   lastImplementation: ImplementationResult | null;
   events: CycleEvent[];
+}
+
+/**
+ * Fleet-wide slot limiter. Each repo drives its OWN loop (see startDaemon), so
+ * nothing else bounds how many agent sessions exist at once — twenty repos
+ * waking together would be twenty concurrent Claude sessions and twenty streams
+ * of GitHub calls. Slots are held for the whole of a repo's pass and released
+ * even when the pass throws, so one crashing repo cannot leak the fleet's
+ * capacity away one slot at a time.
+ */
+let slotLimit = 3;
+let slotsInUse = 0;
+const slotWaiters: Array<() => void> = [];
+
+export function setConcurrencyLimit(limit: number): void {
+  slotLimit = Math.max(1, limit);
+  // A raised limit must wake anyone already queued, or a config reload that
+  // increases capacity would have no effect until the next natural release.
+  while (slotsInUse < slotLimit && slotWaiters.length > 0) {
+    const wake = slotWaiters.shift();
+    if (wake) {
+      slotsInUse++;
+      wake();
+    }
+  }
+}
+
+async function acquireSlot(): Promise<void> {
+  if (slotsInUse < slotLimit) {
+    slotsInUse++;
+    return;
+  }
+  await new Promise<void>((resolve) => slotWaiters.push(resolve));
+}
+
+function releaseSlot(): void {
+  const wake = slotWaiters.shift();
+  if (wake) {
+    wake(); // hand the slot straight to the next waiter; count stays put
+    return;
+  }
+  slotsInUse = Math.max(0, slotsInUse - 1);
+}
+
+/** Repos waiting for a slot right now — surfaced so a queue that stops moving
+ *  is visible rather than looking like an idle fleet. */
+export function getQueuedRepoCount(): number {
+  return slotWaiters.length;
+}
+
+/**
+ * Run one pass for one repo, holding a fleet concurrency slot for its duration.
+ * This is what a per-repo loop calls.
+ */
+export async function runRepoPass(
+  repoConfig: RepoConfig,
+  config: AgentConfig,
+  logger: Logger,
+): Promise<RepoCycleResult> {
+  await acquireSlot();
+  try {
+    return await runRepoCycle(repoConfig, config, logger, 0);
+  } finally {
+    releaseSlot();
+  }
 }
 
 /**
@@ -150,6 +215,11 @@ async function runRepoCycle(
 
   const repoCycle = (repoCycleCounter.get(repoConfig.name) ?? 0) + 1;
   repoCycleCounter.set(repoConfig.name, repoCycle);
+  // The phase helpers use the cycle number for per-repo failure cooldowns
+  // ("retry after N idle cycles"), so they must count THIS repo's passes. With
+  // independent per-repo loops a fleet-wide counter no longer maps to a repo's
+  // own turns, and a cooldown measured in someone else's cycles is arbitrary.
+  cycleNumber = repoCycle;
   const base = logger.child({ cycle: cycleNumber, repoCycle, repo: repoConfig.name });
 
   // --- Phase 0: Reconcile orphaned commits (features ahead of develop with no PR) ---

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -455,6 +455,42 @@ async function runRepoCycle(
       events.push({ message: `Reconciled ${repoConfig.githubRepo} — ${result.commitCount} orphaned commit(s), PR: ${result.prUrl}`, level: "info" });
       processed++;
     }
+
+    // A rejected branch is a STANDING condition, not an event: the commits sit
+    // ahead of base every cycle until someone reverts them. Alert ONCE per head
+    // SHA — same discipline as the dead-zone alerts below, for the same reason
+    // (a per-cycle repeat is indistinguishable from noise and gets muted).
+    //
+    // Deliberately detection-only. The cure is to revert the rejected diff off the
+    // shared branch, and that is a destructive push to a branch other work rides
+    // on — on a protected branch it is not even possible (HTTP 422). Doing it
+    // automatically could discard legitimate unmerged work, so the Foreman reports
+    // and a human decides. See slashbin-ai-foreman#24.
+    for (const r of result.rejected ?? []) {
+      const state = loadRepoState(repoConfig.name);
+      const alreadyAlerted = (state.rejectedBranches ?? {})[r.branch];
+      if (alreadyAlerted === r.headSha) continue;
+
+      const issues = r.issueNumbers.length > 0
+        ? ` (issues ${r.issueNumbers.map((n) => `#${n}`).join(", ")})`
+        : "";
+      reconLogger.warn(
+        `${r.branch} carries ${r.commitCount} rejected commit(s) — PR #${r.prNumber} was closed unmerged ` +
+        `and nothing has changed since. Reconciliation is blocked until the diff is reverted off the branch.`,
+        { branch: r.branch, headSha: r.headSha, rejectedPR: r.prUrl },
+      );
+      events.push({
+        message:
+          `⚠️ ${repoConfig.githubRepo} — \`${r.branch}\` still carries the ${r.commitCount} commit(s) from ` +
+          `PR #${r.prNumber}, which was closed unmerged${issues}. The Foreman will NOT recreate that PR. ` +
+          `Revert the diff off \`${r.branch}\`, or those commits ride along in the next PR from this branch. ${r.prUrl}`,
+        level: "warn",
+      });
+
+      const fresh = loadRepoState(repoConfig.name);
+      fresh.rejectedBranches = { ...(fresh.rejectedBranches ?? {}), [r.branch]: r.headSha };
+      saveRepoState(repoConfig.name, fresh);
+    }
   } catch (err) {
     reconLogger.error("Reconciliation failed", {
       error: err instanceof Error ? err.message : String(err),

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -33,6 +33,9 @@ import {
   findIssuesStillUnderReview,
   resolveDeadZone,
   transitionReviewOutcomeLabel,
+  snapshotEmGate,
+  restoreEmGate,
+  EM_GATE_LABEL,
 } from "./github.js";
 import type { ReviewTrailer } from "./agent.js";
 import { loadRepoState, saveRepoState } from "./state.js";
@@ -53,6 +56,11 @@ const failureHitMaxAt = new Map<string, number>(); // cycle when max was hit
 const revisionFailureCount = new Map<string, number>();
 const reviewFailureCount = new Map<string, number>();
 const reviewFailureHitMaxAt = new Map<string, number>();
+
+// Last cycle on which each repo checked whether an empty ready-for-prod set is
+// actually a stall. Rate-limits one compare API call per repo; see tryPromotion.
+const lastStallCheckCycle = new Map<string, number>();
+const STALL_CHECK_CYCLE_INTERVAL = 12;
 
 /** Per-repo set of issue numbers already alerted as dead-zoned, so a STANDING
  *  condition alerts once instead of every reconcile cycle. Cleared per-issue when
@@ -1142,6 +1150,14 @@ async function tryReview(
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
   const transcriptPath = resolve(process.cwd(), "logs", "review", `${repoName}-cycle${cycleNumber}-${ts}.log`);
 
+  // Snapshot the EM outcome-gate BEFORE the run. `findPRsNeedingReview` already
+  // excludes advanced issues, but it decided that minutes ago; a gate signed
+  // while this run is in flight is invisible to it and gets overwritten by the
+  // run's own label write. Restored in `finally`, so a crash cannot strand it.
+  const gatedBeforeReview = snapshotEmGate(
+    repoConfig.githubRepo, repoConfig.repoPath, candidate.issueNumbers, reviewLogger,
+  );
+
   const runAbort = new AbortController();
   activeRuns.set(repoName, runAbort);
   reviewLogger.info(`Triggering review for ${repoName} — PR #${candidate.prNumber} (issues: ${candidate.issueNumbers.map(n => `#${n}`).join(", ")}), transcript: ${transcriptPath}`);
@@ -1224,6 +1240,16 @@ async function tryReview(
     return false;
   } finally {
     activeRuns.delete(repoName);
+
+    // Undo any revocation of the EM outcome-gate. In `finally` on purpose: a run
+    // that threw or was aborted may still have written labels before it died.
+    const restored = restoreEmGate(repoConfig, gatedBeforeReview, reviewLogger);
+    if (restored.length > 0) {
+      events?.push({
+        message: `⚠️ ${repoConfig.githubRepo} — the review run removed "${EM_GATE_LABEL}" from issue(s) ${restored.map((n) => `#${n}`).join(", ")}; restored. Promotion would otherwise have stalled silently.`,
+        level: "warn",
+      });
+    }
   }
 }
 
@@ -1280,7 +1306,30 @@ function tryPromotion(
   }
 
   const issues = findReadyForProdIssues(repoConfig.githubRepo, repoConfig.repoPath, promoLogger);
-  if (issues.length === 0) return null;
+  if (issues.length === 0) {
+    // "Nothing ready to promote" and "the gate was revoked and promotion is
+    // stalled" produce the identical empty set and the identical silence. They
+    // are distinguishable by one fact: whether `develop` is carrying merged work
+    // that never reached `main`. Say so when it is.
+    //
+    // Rate-limited because it costs a compare API call and the discovery budget
+    // is repos x cycles/hour (see docs on the GitHub API budget) — a stall lasts
+    // cycles, so hourly is early enough to catch it and cheap enough to keep.
+    const last = lastStallCheckCycle.get(repoName) ?? -Infinity;
+    if (cycleNumber - last >= STALL_CHECK_CYCLE_INTERVAL) {
+      lastStallCheckCycle.set(repoName, cycleNumber);
+      const drift = checkBranchDrift(repoConfig.githubRepo, repoConfig.repoPath, promoLogger);
+      if (drift && drift.developAheadOfMain > 0) {
+        promoLogger.warn(
+          `${repoName}: develop is ${drift.developAheadOfMain} commit(s) ahead of main but no issue carries ` +
+          `"${EM_GATE_LABEL}" — promotion is STALLED, not idle. Either the EM gate has not been signed yet, ` +
+          `or it was signed and revoked.`,
+          { developAheadOfMain: drift.developAheadOfMain },
+        );
+      }
+    }
+    return null;
+  }
 
   promoLogger.info(`Found ${issues.length} issue(s) ready for prod release`);
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -605,9 +605,14 @@ async function tryReview(
     if (result.success) {
       reviewFailureCount.set(repoName, 0);
       reviewFailureHitMaxAt.delete(repoName);
-      const summaryLine = (result.summary || "review completed").split("\n")[0].slice(0, 240);
       reviewLogger.info(`Review run completed for ${repoName}`);
-      events?.push({ message: `Reviewed ${repoConfig.githubRepo} PR #${candidate.prNumber} — ${summaryLine}`, level: "info" });
+      // Prefer the structured per-PR status (includes deploy SUCCESS/FAILURE);
+      // fall back to the summary's first line when no trailer was emitted.
+      const outcome = result.statusLine
+        ? result.statusLine
+        : (result.summary || "review completed").split("\n")[0].slice(0, 240);
+      const prefix = result.statusLine ? "" : `PR #${candidate.prNumber} — `;
+      events?.push({ message: `Reviewed ${repoConfig.githubRepo} — ${prefix}${outcome}`, level: "info" });
       return true;
     }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1319,12 +1319,16 @@ function tryPromotion(
     if (cycleNumber - last >= STALL_CHECK_CYCLE_INTERVAL) {
       lastStallCheckCycle.set(repoName, cycleNumber);
       const drift = checkBranchDrift(repoConfig.githubRepo, repoConfig.repoPath, promoLogger);
-      if (drift && drift.developAheadOfMain > 0) {
+      // Gate on CHANGED FILES, never on commit count. Every repo sits 1 commit
+      // ahead in the steady state — the main -> develop sync PR's merge commit,
+      // which carries no file change. Warning on `ahead > 0` fires on every repo
+      // on every check, forever, and a warning that is always on is not a signal.
+      if (drift && drift.developAheadFiles > 0) {
         promoLogger.warn(
-          `${repoName}: develop is ${drift.developAheadOfMain} commit(s) ahead of main but no issue carries ` +
-          `"${EM_GATE_LABEL}" — promotion is STALLED, not idle. Either the EM gate has not been signed yet, ` +
-          `or it was signed and revoked.`,
-          { developAheadOfMain: drift.developAheadOfMain },
+          `${repoName}: develop carries ${drift.developAheadFiles} changed file(s) not on main ` +
+          `(${drift.developAheadOfMain} commit(s) ahead) but no issue carries "${EM_GATE_LABEL}" — ` +
+          `promotion is STALLED, not idle. Either the EM gate has not been signed yet, or it was signed and revoked.`,
+          { developAheadOfMain: drift.developAheadOfMain, developAheadFiles: drift.developAheadFiles },
         );
       }
     }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -33,8 +33,13 @@ import { loadRepoState, saveRepoState } from "./state.js";
 
 const MAX_RETRIES = 2;
 
-let implementing: string | null = null; // repo name, or null
-let abortController: AbortController | null = null;
+// Agent runs in flight, keyed by repo name. Repos progress CONCURRENTLY (one
+// queue per service — see runCycle), so "the" in-flight run stopped being a
+// single thing; a lone `abortController` would have tracked whichever repo
+// started last and let a restart SIGKILL every other repo's half-built branch.
+// One entry per repo, at most — a repo's own phases stay strictly sequential
+// because they share one git working clone.
+const activeRuns = new Map<string, AbortController>();
 
 // Per-repo consecutive batch failure count with cooldown
 const failureCount = new Map<string, number>();
@@ -53,6 +58,9 @@ const lastFailureReason = new Map<string, string>(); // per-repo last failure fo
 
 export interface OrchestratorState {
   implementing: string | null;
+  /** Every repo with an agent run in flight. `implementing` is the first of
+   *  these, kept for callers that predate concurrency. */
+  implementingRepos: string[];
   repos: Record<string, { failures: number; revisionFailures: number }>;
 }
 
@@ -64,11 +72,32 @@ export function getState(config: AgentConfig): OrchestratorState {
       revisionFailures: revisionFailureCount.get(repo.name) ?? 0,
     };
   }
-  return { implementing, repos };
+  const implementingRepos = [...activeRuns.keys()];
+  return { implementing: implementingRepos[0] ?? null, implementingRepos, repos };
 }
 
+/** Back-compat: a single controller for callers written before concurrency.
+ *  Prefer `getActiveRunCount()` + `abortAllRuns()` — with several repos in
+ *  flight this returns an arbitrary one, and aborting it drains nothing else. */
 export function getAbortController(): AbortController | null {
-  return abortController;
+  for (const ac of activeRuns.values()) return ac;
+  return null;
+}
+
+/** How many agent runs are in flight right now, across all repos. */
+export function getActiveRunCount(): number {
+  return activeRuns.size;
+}
+
+/** Repos currently running an agent, for shutdown logging. */
+export function getActiveRunRepos(): string[] {
+  return [...activeRuns.keys()];
+}
+
+/** Abort every in-flight run. Only for a shutdown whose drain window elapsed —
+ *  this destroys work in progress. */
+export function abortAllRuns(): void {
+  for (const ac of activeRuns.values()) ac.abort();
 }
 
 export interface CycleEvent {
@@ -82,6 +111,153 @@ export interface CycleResult {
   events: CycleEvent[];
 }
 
+/** Per-repo cycle counter. The fleet-wide `cycle=N` alone became unreadable the
+ *  moment repos ran concurrently — twenty repos interleaving under one number
+ *  gives no way to follow a single service's progress, and an unreadable log is
+ *  how a stalled queue hides. Every line now carries both: `cycle` (fleet) and
+ *  `repoCycle` (this service's own pass count). */
+const repoCycleCounter = new Map<string, number>();
+
+interface RepoCycleResult {
+  processed: number;
+  lastImplementation: ImplementationResult | null;
+  events: CycleEvent[];
+}
+
+/**
+ * One full pass over ONE repo: reconcile -> review -> revise -> implement ->
+ * sync -> promote.
+ *
+ * Phase order within a repo is load-bearing and unchanged. Review runs before
+ * implement so it only acts on PRs labeled in a PRIOR pass (a PR created by
+ * this pass waits for the next one, avoiding a same-cycle GitHub-consistency
+ * race). Promote runs last so it sees labels this pass just set.
+ *
+ * What changed is that this is now the unit of concurrency. Repos no longer
+ * queue behind each other: a 30-minute build on one service used to block the
+ * other nineteen, because the old shape was six sequential loops over all
+ * repos and every phase awaited each one in turn.
+ */
+async function runRepoCycle(
+  repoConfig: RepoConfig,
+  config: AgentConfig,
+  logger: Logger,
+  cycleNumber: number,
+): Promise<RepoCycleResult> {
+  const events: CycleEvent[] = [];
+  let processed = 0;
+  let lastImplementation: ImplementationResult | null = null;
+
+  const repoCycle = (repoCycleCounter.get(repoConfig.name) ?? 0) + 1;
+  repoCycleCounter.set(repoConfig.name, repoCycle);
+  const base = logger.child({ cycle: cycleNumber, repoCycle, repo: repoConfig.name });
+
+  // --- Phase 0: Reconcile orphaned commits (features ahead of develop with no PR) ---
+  const reconLogger = base.child({ phase: "reconcile" });
+  try {
+    const result = reconcileRepo(repoConfig, reconLogger);
+    if (result.reconciled) {
+      reconLogger.info(
+        `Reconciled ${result.commitCount} orphaned commit(s) — PR created: ${result.prUrl}`,
+        { issues: result.issueNumbers },
+      );
+      events.push({ message: `Reconciled ${repoConfig.githubRepo} — ${result.commitCount} orphaned commit(s), PR: ${result.prUrl}`, level: "info" });
+      processed++;
+    }
+  } catch (err) {
+    reconLogger.error("Reconciliation failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Surface dead-zoned issues: PR merged to develop but the issue is still
+  // `pr under review` (post-merge verify failed and no phase recovers it).
+  // Detection only — the EM re-verifies and advances/flags by hand.
+  //
+  // ALERT ONCE per (repo, issue). The dead-zone is a STANDING condition, not an
+  // event: it persists every cycle until the EM clears it, so re-emitting each
+  // reconcile pass floods Discord with the identical line (~every 2 min) and
+  // trains the reader to ignore the channel — the alarm defeats itself.
+  // Observed 2026-07-19 on Slashbin-console#661 (Ray: "i keep seeing this
+  // messages"). The warning fires on transition INTO the dead-zone; the entry
+  // clears when the issue leaves it, so a genuine re-entry alerts again.
+  try {
+    const stuck = findStuckMergedIssues(repoConfig, reconLogger);
+    const seen = deadZoneAlerted.get(repoConfig.name) ?? new Set<number>();
+    const current = new Set(stuck.map((s) => s.issueNumber));
+    for (const s of stuck) {
+      if (seen.has(s.issueNumber)) continue; // already alerted; still stuck
+      seen.add(s.issueNumber);
+      reconLogger.warn(
+        `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it`,
+        { prUrl: s.prUrl, mergedAt: s.mergedAt },
+      );
+      events.push({
+        message: `⚠️ ${repoConfig.githubRepo} #${s.issueNumber} dead-zoned: PR #${s.prNumber} merged but issue still "pr under review". EM: re-verify (npm run verify --repo ${repoConfig.name} --pr ${s.prNumber} --env development), then advance to "ready for prod release" or flag "pr pending actions".`,
+        level: "warn",
+      });
+    }
+    // Drop cleared issues so a real re-entry alerts again.
+    for (const n of [...seen]) if (!current.has(n)) seen.delete(n);
+    deadZoneAlerted.set(repoConfig.name, seen);
+  } catch (err) {
+    reconLogger.debug(
+      `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // --- Phase 1: Review open feature PRs (invokes the EM /review-all-prs skill) ---
+  if (await tryReview(repoConfig, config, base, cycleNumber, events)) processed++;
+
+  // --- Phase 2: Revise PRs with pending review feedback ---
+  const revisionInfo = await tryRevision(repoConfig, base, cycleNumber);
+  if (revisionInfo) {
+    events.push({ message: `Revised ${repoConfig.githubRepo} PR #${revisionInfo.pr.number} (issues: ${revisionInfo.issueNumbers.map(n => `#${n}`).join(", ")})`, level: "info" });
+    processed++;
+  }
+
+  // --- Phase 3: Implement approved issues (one batch per repo) ---
+  const implResult = await tryBatchImplementation(repoConfig, config, base, cycleNumber, events);
+  if (implResult) {
+    processed++;
+    lastImplementation = implResult;
+  }
+
+  // --- Phase 4: Reconcile branch drift (main → develop) for any repo with
+  //    post-promotion merge commits. Runs independently of promotion work so
+  //    drift is cleared even when no ready-for-prod issues exist. ---
+  if (!(repoConfig.baseBranch === "main" && repoConfig.featureBranch === "main")) {
+    if (trySyncDrift(repoConfig, base, cycleNumber)) {
+      events.push({ message: `Branch sync on ${repoConfig.githubRepo} (main → develop) — merged`, level: "info" });
+      processed++;
+    }
+  }
+
+  // --- Phase 5: Create promotion PRs for repos with ready-for-prod issues ---
+  const promotionResult = tryPromotion(repoConfig, base, cycleNumber);
+  if (promotionResult === "promoted") {
+    events.push({ message: `Promotion PR created on ${repoConfig.githubRepo} (develop → main)`, level: "info" });
+    processed++;
+  } else if (promotionResult === "synced") {
+    events.push({ message: `Branch sync on ${repoConfig.githubRepo} (main → develop) — merged, promotion will follow`, level: "info" });
+    processed++;
+  }
+
+  return { processed, lastImplementation, events };
+}
+
+/**
+ * One fleet pass: every repo runs its own pipeline, several at a time.
+ *
+ * The cap is about SPEND, not safety. Concurrent repos are safe on their own —
+ * each has its own git working clone, so two of them can never touch the same
+ * checkout, and a repo's phases stay sequential within `runRepoCycle`. What a
+ * high cap actually buys you is N simultaneous Claude sessions (each up to 100
+ * turns) and N times the GitHub API traffic, on an API that already returns
+ * intermittent TLS timeouts at one.
+ *
+ * Set `maxConcurrentRepos` in .ai-agent.json or AI_AGENT_MAX_CONCURRENT_REPOS.
+ */
 export async function runCycle(
   config: AgentConfig,
   logger: Logger,
@@ -93,117 +269,34 @@ export async function runCycle(
   let lastResult: ImplementationResult | null = null;
   const events: CycleEvent[] = [];
 
-  // --- Phase 0: Reconcile orphaned commits (features ahead of develop with no PR) ---
-  for (const repoConfig of config.repos) {
-    const reconLogger = logger.child({ cycle: cycleNumber, repo: repoConfig.name, phase: "reconcile" });
-    try {
-      const result = reconcileRepo(repoConfig, reconLogger);
-      if (result.reconciled) {
-        reconLogger.info(
-          `Reconciled ${result.commitCount} orphaned commit(s) — PR created: ${result.prUrl}`,
-          { issues: result.issueNumbers },
-        );
-        events.push({ message: `Reconciled ${repoConfig.githubRepo} — ${result.commitCount} orphaned commit(s), PR: ${result.prUrl}`, level: "info" });
-        totalProcessed++;
-      }
-    } catch (err) {
-      reconLogger.error("Reconciliation failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  const limit = Math.max(1, Math.min(config.maxConcurrentRepos, config.repos.length));
+  const queue = [...config.repos];
 
-    // Surface dead-zoned issues: PR merged to develop but the issue is still
-    // `pr under review` (post-merge verify failed and no phase recovers it).
-    // Detection only — the EM re-verifies and advances/flags by hand.
-    //
-    // ALERT ONCE per (repo, issue). The dead-zone is a STANDING condition, not an
-    // event: it persists every cycle until the EM clears it, so re-emitting each
-    // reconcile pass floods Discord with the identical line (~every 2 min) and
-    // trains the reader to ignore the channel — the alarm defeats itself.
-    // Observed 2026-07-19 on Slashbin-console#661 (Ray: "i keep seeing this
-    // messages"). The warning fires on transition INTO the dead-zone; the entry
-    // clears when the issue leaves it, so a genuine re-entry alerts again.
-    try {
-      const stuck = findStuckMergedIssues(repoConfig, reconLogger);
-      const seen = deadZoneAlerted.get(repoConfig.name) ?? new Set<number>();
-      const current = new Set(stuck.map((s) => s.issueNumber));
-      for (const s of stuck) {
-        if (seen.has(s.issueNumber)) continue; // already alerted; still stuck
-        seen.add(s.issueNumber);
-        reconLogger.warn(
-          `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it`,
-          { prUrl: s.prUrl, mergedAt: s.mergedAt },
-        );
-        events.push({
-          message: `⚠️ ${repoConfig.githubRepo} #${s.issueNumber} dead-zoned: PR #${s.prNumber} merged but issue still "pr under review". EM: re-verify (npm run verify --repo ${repoConfig.name} --pr ${s.prNumber} --env development), then advance to "ready for prod release" or flag "pr pending actions".`,
-          level: "warn",
+  if (limit > 1) {
+    cycleLogger.debug(`Running ${config.repos.length} repo(s), up to ${limit} concurrently`);
+  }
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const repoConfig = queue.shift();
+      if (!repoConfig) return;
+      try {
+        const result = await runRepoCycle(repoConfig, config, logger, cycleNumber);
+        totalProcessed += result.processed;
+        events.push(...result.events);
+        if (result.lastImplementation) lastResult = result.lastImplementation;
+      } catch (err) {
+        // One repo's pipeline must never take the fleet pass down with it —
+        // that would be the serial failure mode reintroduced through the back
+        // door, with every other repo starved by an unrelated crash.
+        logger.child({ cycle: cycleNumber, repo: repoConfig.name }).error("Repo cycle failed", {
+          error: err instanceof Error ? err.message : String(err),
         });
       }
-      // Drop cleared issues so a real re-entry alerts again.
-      for (const n of [...seen]) if (!current.has(n)) seen.delete(n);
-      deadZoneAlerted.set(repoConfig.name, seen);
-    } catch (err) {
-      reconLogger.debug(
-        `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,
-      );
     }
-  }
+  };
 
-  // --- Phase 1: Review open feature PRs (invokes the EM /review-all-prs skill) ---
-  // Runs FIRST among the PR-acting phases so it only acts on PRs labeled
-  // `pr under review` in a PRIOR cycle (labels settled). PRs created by THIS
-  // cycle's implement phase wait for next cycle's review — avoids a same-cycle
-  // GitHub-consistency race. The skill owns its own label transitions and merges;
-  // its side effects (`ready for prod release` / `pr pending actions`) feed the
-  // promote and revise phases respectively.
-  for (const repoConfig of config.repos) {
-    const reviewed = await tryReview(repoConfig, config, logger, cycleNumber, events);
-    if (reviewed) {
-      totalProcessed++;
-    }
-  }
-
-  // --- Phase 2: Revise PRs with pending review feedback ---
-  for (const repoConfig of config.repos) {
-    const revisionInfo = await tryRevision(repoConfig, logger, cycleNumber);
-    if (revisionInfo) {
-      events.push({ message: `Revised ${repoConfig.githubRepo} PR #${revisionInfo.pr.number} (issues: ${revisionInfo.issueNumbers.map(n => `#${n}`).join(", ")})`, level: "info" });
-      totalProcessed++;
-    }
-  }
-
-  // --- Phase 3: Implement approved issues (one batch per repo) ---
-  for (const repoConfig of config.repos) {
-    const result = await tryBatchImplementation(repoConfig, config, logger, cycleNumber, events);
-    if (result) {
-      totalProcessed++;
-      lastResult = result;
-    }
-  }
-
-  // --- Phase 4: Reconcile branch drift (main → develop) for any repo with
-  //    post-promotion merge commits. Runs independently of promotion work so
-  //    drift is cleared even when no ready-for-prod issues exist. ---
-  for (const repoConfig of config.repos) {
-    if (repoConfig.baseBranch === "main" && repoConfig.featureBranch === "main") continue;
-    const synced = trySyncDrift(repoConfig, logger, cycleNumber);
-    if (synced) {
-      events.push({ message: `Branch sync on ${repoConfig.githubRepo} (main → develop) — merged`, level: "info" });
-      totalProcessed++;
-    }
-  }
-
-  // --- Phase 5: Create promotion PRs for repos with ready-for-prod issues ---
-  for (const repoConfig of config.repos) {
-    const promotionResult = tryPromotion(repoConfig, logger, cycleNumber);
-    if (promotionResult === "promoted") {
-      events.push({ message: `Promotion PR created on ${repoConfig.githubRepo} (develop → main)`, level: "info" });
-      totalProcessed++;
-    } else if (promotionResult === "synced") {
-      events.push({ message: `Branch sync on ${repoConfig.githubRepo} (main → develop) — merged, promotion will follow`, level: "info" });
-      totalProcessed++;
-    }
-  }
+  await Promise.all(Array.from({ length: limit }, () => worker()));
 
   if (totalProcessed === 0) {
     cycleLogger.info("No work across all repos");
@@ -416,13 +509,13 @@ async function tryBatchImplementation(
   // exists, the skill creates one. If one exists, new commits are added to it.
 
   // Invoke the skill — one Claude session implements all approved issues
-  implementing = repoName;
-  abortController = new AbortController();
+  const runAbort = new AbortController();
+  activeRuns.set(repoName, runAbort);
   repoLogger.info(`Triggering batch implementation for ${repoName}`);
 
   try {
     const priorFailure = lastFailureReason.get(repoName) || null;
-    const result = await implementApprovedIssues(repoConfig, repoLogger, abortController.signal, priorFailure, actionableIssues);
+    const result = await implementApprovedIssues(repoConfig, repoLogger, runAbort.signal, priorFailure, actionableIssues);
 
     if (result.success) {
       failureCount.set(repoName, 0);
@@ -595,8 +688,7 @@ async function tryBatchImplementation(
 
     return result;
   } finally {
-    implementing = null;
-    abortController = null;
+    activeRuns.delete(repoName);
   }
 }
 
@@ -623,13 +715,13 @@ async function tryRevision(
   }
 
   // Invoke the revision skill with specific PR and issue context
-  implementing = repoName;
-  abortController = new AbortController();
+  const runAbort = new AbortController();
+  activeRuns.set(repoName, runAbort);
   revLogger.info(`Triggering PR revision for ${repoName} — PR #${pending.pr.number}, issues: ${pending.issueNumbers.map(n => `#${n}`).join(", ")}`);
 
   try {
     const result = await revisePRFeedback(
-      repoConfig, revLogger, abortController.signal,
+      repoConfig, revLogger, runAbort.signal,
       pending.pr.number, pending.issueNumbers,
     );
 
@@ -656,8 +748,7 @@ async function tryRevision(
 
     return null;
   } finally {
-    implementing = null;
-    abortController = null;
+    activeRuns.delete(repoName);
   }
 }
 
@@ -708,13 +799,13 @@ async function tryReview(
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
   const transcriptPath = resolve(process.cwd(), "logs", "review", `${repoName}-cycle${cycleNumber}-${ts}.log`);
 
-  implementing = repoName;
-  abortController = new AbortController();
+  const runAbort = new AbortController();
+  activeRuns.set(repoName, runAbort);
   reviewLogger.info(`Triggering review for ${repoName} — PR #${candidate.prNumber} (issues: ${candidate.issueNumbers.map(n => `#${n}`).join(", ")}), transcript: ${transcriptPath}`);
   events?.push({ message: `Reviewing ${repoConfig.githubRepo} PR #${candidate.prNumber} (issues: ${candidate.issueNumbers.map(n => `#${n}`).join(", ")})`, level: "info" });
 
   try {
-    const result = await reviewOpenPRs(repoConfig, config, reviewLogger, abortController.signal, transcriptPath);
+    const result = await reviewOpenPRs(repoConfig, config, reviewLogger, runAbort.signal, transcriptPath);
 
     if (result.success) {
       reviewFailureCount.set(repoName, 0);
@@ -737,8 +828,7 @@ async function tryReview(
     events?.push({ message: `Review failed on ${repoConfig.githubRepo} PR #${candidate.prNumber}: ${result.error}`, level: "error" });
     return false;
   } finally {
-    implementing = null;
-    abortController = null;
+    activeRuns.delete(repoName);
   }
 }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -32,7 +32,9 @@ import {
   transitionToReadyForProd,
   findIssuesStillUnderReview,
   resolveDeadZone,
+  transitionReviewOutcomeLabel,
 } from "./github.js";
+import type { ReviewTrailer } from "./agent.js";
 import { loadRepoState, saveRepoState } from "./state.js";
 
 const MAX_RETRIES = 2;
@@ -141,6 +143,120 @@ function recoverDeadZonedIssue(
     `Dead-zone recovery INDETERMINATE for #${issueNumber} — verifier exited ${run.status} (no verdict; repo may have no service mapping): ${(run.stderr || "").split("\n")[0]}`,
   );
   return "indeterminate";
+}
+
+/**
+ * The label a review run's own trailer implies for the issues its PR closed, or
+ * null when the trailer does not warrant a write.
+ *
+ * Null is the important half. The reconciler exists to repair a MISSING write,
+ * never to invent one, so anything the trailer does not say plainly is left for a
+ * human — an unmerged PR (the issue is legitimately still under review), or a
+ * self-contradictory report like `verdict=REQUEST_CHANGES merged=yes`.
+ *
+ * `deploy=NA` is a PASS, not an absence: it is what a repo with nothing to deploy
+ * (docs, CLI, npm package) is instructed to emit.
+ */
+export function labelFromTrailer(t: ReviewTrailer): "pr approved" | "pr pending actions" | null {
+  if (!t.merged) return null;
+  if (t.verdict !== "APPROVE") return null;
+  if (/^(FAIL|FAILURE|FAILED)$/.test(t.deploy)) return "pr pending actions";
+  if (/^(SUCCESS|OK|PASS|PASSED|NA|N\/A|NONE)$/.test(t.deploy)) return "pr approved";
+  return null;
+}
+
+/**
+ * Set the outcome label the review run reported, for issues it merged but left at
+ * `pr under review`.
+ *
+ * This is the fix for the pipeline's oldest silent failure: the merge was done by
+ * code while the RECORD of it was left to an agent to remember to write, so ~23%
+ * of merges (12 of 53 over 2026-07-29 → 08-04) stranded their issue in a state no
+ * phase reads. The outcome was never actually unknown — it arrived in a
+ * machine-readable trailer the Foreman already parsed and logged. This spends it.
+ *
+ * Four independent conditions gate every write, so the reconciler cannot invent
+ * state or overrule anyone:
+ *   1. the issue is STILL at `pr under review` with no outcome label — a run that
+ *      labeled correctly never reaches this code, so healthy behavior is unchanged;
+ *   2. a merged PR provably closed that issue, via the same STRICT predicate the
+ *      promotion path uses (`findIssuesMergedToBase` — a bare "related to #N"
+ *      never counts);
+ *   3. that PR has a trailer from THIS run whose fields are unambiguous;
+ *   4. the reviewer did not declare a deliberate hold.
+ *
+ * It never applies `ready for prod release`: that label authorizes production and
+ * stays the EM outcome-gate's signature (separation of duties, 2026-07-27).
+ *
+ * Returns the issues still stuck after reconciliation — the genuine dead zone.
+ */
+function reconcileReviewOutcomeLabels(
+  repoConfig: RepoConfig,
+  stuck: number[],
+  trailers: ReviewTrailer[],
+  logger: Logger,
+  events?: CycleEvent[],
+): number[] {
+  const merged = findIssuesMergedToBase(repoConfig, stuck, logger);
+  const byIssue = new Map(merged.map((m) => [m.issueNumber, m]));
+  const unresolved: number[] = [];
+  let held: { issue: number; reason: string; pr: number }[] = [];
+
+  for (const issueNumber of stuck) {
+    const ref = byIssue.get(issueNumber);
+    if (!ref) {
+      // No merged PR closes it — it is not in the dead zone at all; the PR is
+      // still open and the issue is correctly `pr under review`.
+      continue;
+    }
+    const trailer = trailers.find((t) => t.pr === ref.prNumber);
+    if (!trailer) {
+      unresolved.push(issueNumber);
+      continue;
+    }
+    if (trailer.hold) {
+      held.push({ issue: issueNumber, reason: trailer.hold, pr: ref.prNumber });
+      continue;
+    }
+    const label = labelFromTrailer(trailer);
+    if (!label) {
+      logger.warn(
+        `Not reconciling #${issueNumber}: PR #${ref.prNumber}'s trailer is ambiguous (verdict=${trailer.verdict} merged=${trailer.merged} deploy=${trailer.deploy}) — leaving it for a human`,
+      );
+      unresolved.push(issueNumber);
+      continue;
+    }
+    if (transitionReviewOutcomeLabel(repoConfig, issueNumber, label, logger)) {
+      events?.push({
+        message: `${repoConfig.githubRepo} #${issueNumber} — review merged PR #${ref.prNumber} without labeling; reconciled to "${label}" from its own trailer`,
+        level: label === "pr approved" ? "info" : "warn",
+      });
+    } else {
+      unresolved.push(issueNumber);
+    }
+  }
+
+  // Persist declared holds so neither this reconciler nor the dead-zone recovery
+  // overwrites a deliberate decision on a later cycle or after a restart. The
+  // in-memory skip sets would not survive either.
+  if (held.length > 0) {
+    const state = loadRepoState(repoConfig.name);
+    if (!state.held) state.held = {};
+    const at = new Date().toISOString();
+    for (const h of held) {
+      state.held[h.issue] = { heldAt: at, prNumber: h.pr, reason: h.reason };
+      logger.info(
+        `#${h.issue} held by the reviewer (PR #${h.pr}): ${h.reason} — leaving "pr under review" in place, not re-verifying`,
+      );
+      events?.push({
+        message: `⏸️ ${repoConfig.githubRepo} #${h.issue} held by review: ${h.reason} (PR #${h.pr} merged; label intentionally withheld)`,
+        level: "info",
+      });
+    }
+    saveRepoState(repoConfig.name, state);
+  }
+
+  return unresolved;
 }
 
 export interface OrchestratorState {
@@ -343,7 +459,29 @@ async function runRepoCycle(
     const seen = deadZoneAlerted.get(repoConfig.name) ?? new Set<number>();
     const tried = deadZoneRecoveryAttempted.get(repoConfig.name) ?? new Set<number>();
     const current = new Set(stuck.map((s) => s.issueNumber));
+
+    // Issues whose reviewer DECLARED a hold are not dead — they are waiting on
+    // purpose. Auto-recovery would re-verify and label them anyway, replacing a
+    // human-grade judgment ("this criterion is not observable until 03:00Z") with
+    // an automated verdict. Surface them, never overwrite them.
+    const repoState = loadRepoState(repoConfig.name);
+    const heldIssues = repoState.held ?? {};
+
     for (const s of stuck) {
+      const hold = heldIssues[s.issueNumber];
+      if (hold) {
+        if (!seen.has(s.issueNumber)) {
+          seen.add(s.issueNumber);
+          reconLogger.info(
+            `Issue #${s.issueNumber} is HELD by its review (PR #${s.prNumber}, since ${hold.heldAt}): ${hold.reason} — not auto-recovering`,
+          );
+          events.push({
+            message: `⏸️ ${repoConfig.githubRepo} #${s.issueNumber} held by review since ${hold.heldAt.slice(0, 16)}: ${hold.reason}. EM: resolve when the criterion can be checked.`,
+            level: "info",
+          });
+        }
+        continue;
+      }
       // --- Recovery first, alert only if it could not be repaired ----------
       // Attempt once per (repo, issue). A second attempt only repeats whatever
       // made the first indeterminate, at the cost of another deploy poll.
@@ -386,6 +524,19 @@ async function runRepoCycle(
     for (const n of [...tried]) if (!current.has(n)) tried.delete(n);
     deadZoneAlerted.set(repoConfig.name, seen);
     deadZoneRecoveryAttempted.set(repoConfig.name, tried);
+
+    // A hold ends when the issue leaves the dead zone (someone set the label or
+    // closed it). Prune, or the record outlives the condition and would suppress
+    // recovery on a genuine re-entry months later.
+    const stale = Object.keys(heldIssues).map(Number).filter((n) => !current.has(n));
+    if (stale.length > 0) {
+      const fresh = loadRepoState(repoConfig.name);
+      if (fresh.held) {
+        for (const n of stale) delete fresh.held[n];
+        saveRepoState(repoConfig.name, fresh);
+        reconLogger.debug(`Cleared ${stale.length} resolved hold(s): #${stale.join(", #")}`);
+      }
+    }
   } catch (err) {
     reconLogger.debug(
       `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1014,18 +1165,38 @@ async function tryReview(
       // where it can re-verify first. Alerting here rather than waiting for the
       // dead-zone sweep skips that path's 15-minute grace window, so a broken
       // run surfaces in the same cycle that produced it.
-      const mergedPrs = (result.trailers ?? []).filter((t) => t.merged).map((t) => t.pr);
+      const trailers = result.trailers ?? [];
+      const mergedPrs = trailers.filter((t) => t.merged).map((t) => t.pr);
       if (mergedPrs.length > 0) {
         const stuck = findIssuesStillUnderReview(repoConfig, candidate.issueNumbers, reviewLogger);
         if (stuck.length > 0) {
-          reviewLogger.error(
-            `Review post-condition FAILED on ${repoName}: PR(s) #${mergedPrs.join(", #")} reported merged, but issue(s) #${stuck.join(", #")} are still "pr under review" — the run merged without completing the label transition`,
+          reviewLogger.warn(
+            `Review post-condition: PR(s) #${mergedPrs.join(", #")} reported merged, but issue(s) #${stuck.join(", #")} are still "pr under review" — the run merged without completing the label transition`,
             { mergedPrs, stuckIssues: stuck },
           );
-          events?.push({
-            message: `⚠️ ${repoConfig.githubRepo} — review merged PR #${mergedPrs.join(", #")} but left issue(s) #${stuck.join(", #")} at "pr under review". Dead-zone recovery will re-verify next cycle.`,
-            level: "warn",
-          });
+
+          // Set the label from the run's own trailer. The verdict is not missing
+          // — it is right here, already parsed. Waiting a cycle to re-derive it
+          // from a fresh deploy poll was spending minutes to recompute an answer
+          // we were holding.
+          const unresolved = config.reviewLabelReconcile
+            ? reconcileReviewOutcomeLabels(repoConfig, stuck, trailers, reviewLogger, events)
+            : stuck;
+
+          if (!config.reviewLabelReconcile && stuck.length > 0) {
+            reviewLogger.info("Label reconciliation disabled (reviewLabelReconcile=false) — leaving the dead zone for recovery");
+          }
+
+          if (unresolved.length > 0) {
+            reviewLogger.error(
+              `Review post-condition UNRESOLVED on ${repoName}: issue(s) #${unresolved.join(", #")} could not be reconciled from the run's trailers — dead-zone recovery will re-verify`,
+              { mergedPrs, unresolved },
+            );
+            events?.push({
+              message: `⚠️ ${repoConfig.githubRepo} — review merged PR #${mergedPrs.join(", #")} but left issue(s) #${unresolved.join(", #")} at "pr under review" and the trailer could not settle it. Dead-zone recovery will re-verify next cycle.`,
+              level: "warn",
+            });
+          }
         }
       }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -800,9 +800,36 @@ function tryPromotion(
   // no-op promotion PR — the ping-pong bug.
   const diffFiles = countBranchDiffFiles(repoConfig.githubRepo, "main", "develop", repoConfig.repoPath, promoLogger);
   if (diffFiles === 0) {
-    promoLogger.info(
-      `Skipping promotion — develop has no file changes vs main despite ${issues.length} ready-for-prod issue(s). ` +
-      `Likely a race with EM verification stripping labels after a recent promotion merged. Labels will clear on next verify cycle.`
+    // TERMINAL EXIT for the promote lifecycle (slashbin-ai-foreman#32, promote variant).
+    //
+    // develop has ZERO file changes vs main, so every ready-for-prod issue's work
+    // is ALREADY in main — it was promoted, and there is nothing left to promote.
+    // Retrying is futile by construction; no future cycle can produce a diff.
+    //
+    // This used to just log "labels will clear on next verify cycle" and return.
+    // They never cleared: stripReadyForProdLabel() is only reachable on the
+    // promotion-PR-created path below, so an already-promoted issue kept the label
+    // forever and this phase re-checked it EVERY cycle, indefinitely. Observed on
+    // jerky_security_testing #110/#115/#117/#118/#122 — stuck from 2026-07-01 for
+    // two weeks, burning a promote check every poll, while their fixes had shipped
+    // to main (and deployed) on day one. The "likely a race" comment was a wrong
+    // assumption that made a permanent stuck state read as self-healing.
+    //
+    // Safe: `ready for prod release` is only applied after the feature PR merges to
+    // develop, so develop-content == main-content ⇒ that work IS in main. Strip the
+    // label to remove them from the promote set. We do NOT close them — the EM still
+    // owns outcome verification; an open issue with no lifecycle label is inert
+    // (the Foreman won't re-pick it) and stays visible for that close.
+    promoLogger.warn(
+      `Already promoted — ${issues.length} issue(s) still labeled 'ready for prod release' but develop has 0 file changes vs main, ` +
+      `so their work is already in main: ${issues.map((i) => `#${i.number}`).join(", ")}. ` +
+      `Stripping the label (nothing left to promote). They remain open for EM outcome-verification + close.`,
+    );
+    stripReadyForProdLabel(
+      repoConfig.githubRepo,
+      issues.map((i) => i.number),
+      repoConfig.repoPath,
+      promoLogger,
     );
     return null;
   }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 import type { AgentConfig, RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import {
@@ -29,6 +30,8 @@ import {
   findStuckMergedIssues,
   findIssuesMergedToBase,
   transitionToReadyForProd,
+  findIssuesStillUnderReview,
+  resolveDeadZone,
 } from "./github.js";
 import { loadRepoState, saveRepoState } from "./state.js";
 
@@ -54,8 +57,91 @@ const reviewFailureHitMaxAt = new Map<string, number>();
  *  the issue leaves the dead-zone, so a genuine re-entry alerts again. */
 const deadZoneAlerted = new Map<string, Set<number>>();
 
+/** Per-repo set of issue numbers we already attempted to auto-recover, so a
+ *  repo whose verification is INDETERMINATE (unmapped service, verifier crash)
+ *  does not re-spend a multi-minute deploy poll on every cycle, forever. */
+const deadZoneRecoveryAttempted = new Map<string, Set<number>>();
+
+/** Ceiling on one dead-zone re-verification. The verifier polls a Railway
+ *  deployment, so minutes are normal and hanging forever is not. */
+const RECOVERY_VERIFY_TIMEOUT_MS = 10 * 60 * 1000;
+
 const FAILURE_COOLDOWN_CYCLES = 3; // retry after this many idle cycles
 const lastFailureReason = new Map<string, string>(); // per-repo last failure for retry context
+
+/**
+ * Repair one dead-zoned issue by re-running the post-merge verification the
+ * failed review never completed, then labeling from ITS verdict.
+ *
+ * This is not a rubber stamp, which is the objection that kept the dead zone
+ * detection-only. The verdict comes from the verifier — a real deploy poll and
+ * healthcheck against the merged commit — not from the agent that dropped the
+ * ball, and not from the mere fact that a merge happened. `pr approved` on PASS
+ * is precisely the state a healthy review would have left behind; `pr pending
+ * actions` on FAIL routes it to the revise phase, which is what a post-merge
+ * FAIL is supposed to do. A FAIL is still a HOLD — it just becomes a hold the
+ * pipeline knows about instead of an issue nobody is looking at.
+ *
+ * `ready for prod release` is never applied here: that label is the EM outcome
+ * gate's signature and stays a human act.
+ *
+ * Returns the verdict, or "indeterminate" when we could not get a trustworthy
+ * answer — an unmapped repo (the verifier exits 2 for a service it has no
+ * Railway mapping for), a verifier crash, or a timeout. Indeterminate changes
+ * NOTHING: the issue stays dead-zoned and alerted, which is strictly better
+ * than guessing at a lifecycle from a verification that never ran.
+ */
+function recoverDeadZonedIssue(
+  repoConfig: RepoConfig,
+  config: AgentConfig,
+  issueNumber: number,
+  prNumber: number,
+  logger: Logger,
+): "pass" | "fail" | "indeterminate" {
+  if (!config.emRepoPath) {
+    logger.debug("Dead-zone recovery skipped — emRepoPath not configured");
+    return "indeterminate";
+  }
+
+  logger.info(
+    `Dead-zone recovery: re-running post-merge verification for #${issueNumber} (PR #${prNumber})`,
+  );
+
+  const run = spawnSync(
+    "npm",
+    [
+      "run", "verify", "--",
+      "--repo", repoConfig.name,
+      "--pr", String(prNumber),
+      "--issue", String(issueNumber),
+      "--env", "development",
+    ],
+    {
+      cwd: config.emRepoPath,
+      encoding: "utf-8",
+      timeout: RECOVERY_VERIFY_TIMEOUT_MS,
+      env: process.env,
+    },
+  );
+
+  if (run.error || run.signal) {
+    logger.warn(
+      `Dead-zone recovery INDETERMINATE for #${issueNumber} — verifier did not complete (${run.signal ? `signal ${run.signal}` : run.error?.message}); leaving the issue as-is`,
+    );
+    return "indeterminate";
+  }
+
+  // The verifier's contract: 0 = all checks pass, 1 = a check failed,
+  // 2 = crash or invalid arguments (including a repo it has no service mapping
+  // for). Only 0 and 1 are verdicts; 2 is an absence of one.
+  if (run.status === 0) return "pass";
+  if (run.status === 1) return "fail";
+
+  logger.warn(
+    `Dead-zone recovery INDETERMINATE for #${issueNumber} — verifier exited ${run.status} (no verdict; repo may have no service mapping): ${(run.stderr || "").split("\n")[0]}`,
+  );
+  return "indeterminate";
+}
 
 export interface OrchestratorState {
   implementing: string | null;
@@ -255,22 +341,51 @@ async function runRepoCycle(
   try {
     const stuck = findStuckMergedIssues(repoConfig, reconLogger);
     const seen = deadZoneAlerted.get(repoConfig.name) ?? new Set<number>();
+    const tried = deadZoneRecoveryAttempted.get(repoConfig.name) ?? new Set<number>();
     const current = new Set(stuck.map((s) => s.issueNumber));
     for (const s of stuck) {
+      // --- Recovery first, alert only if it could not be repaired ----------
+      // Attempt once per (repo, issue). A second attempt only repeats whatever
+      // made the first indeterminate, at the cost of another deploy poll.
+      if (!tried.has(s.issueNumber)) {
+        tried.add(s.issueNumber);
+        const verdict = recoverDeadZonedIssue(
+          repoConfig,
+          config,
+          s.issueNumber,
+          s.prNumber,
+          reconLogger,
+        );
+        if (verdict !== "indeterminate" && resolveDeadZone(repoConfig, s.issueNumber, verdict, reconLogger)) {
+          const label = verdict === "pass" ? "pr approved" : "pr pending actions";
+          events.push({
+            message: `${repoConfig.githubRepo} #${s.issueNumber} dead-zone auto-recovered: re-verification ${verdict.toUpperCase()} → labeled "${label}" (PR #${s.prNumber} was merged with the issue left at "pr under review")`,
+            level: verdict === "pass" ? "info" : "warn",
+          });
+          seen.delete(s.issueNumber);
+          current.delete(s.issueNumber);
+          processed++;
+          continue; // repaired — no dead-zone alert needed
+        }
+      }
+
       if (seen.has(s.issueNumber)) continue; // already alerted; still stuck
       seen.add(s.issueNumber);
       reconLogger.warn(
-        `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it`,
+        `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it, and re-verification produced no verdict`,
         { prUrl: s.prUrl, mergedAt: s.mergedAt },
       );
       events.push({
-        message: `⚠️ ${repoConfig.githubRepo} #${s.issueNumber} dead-zoned: PR #${s.prNumber} merged but issue still "pr under review". EM: re-verify (npm run verify --repo ${repoConfig.name} --pr ${s.prNumber} --env development), then advance to "ready for prod release" or flag "pr pending actions".`,
+        message: `⚠️ ${repoConfig.githubRepo} #${s.issueNumber} dead-zoned: PR #${s.prNumber} merged but issue still "pr under review", and auto re-verification could not produce a verdict. EM: verify by hand (npm run verify -- --repo ${repoConfig.name} --pr ${s.prNumber} --env development), then advance to "ready for prod release" or flag "pr pending actions".`,
         level: "warn",
       });
     }
-    // Drop cleared issues so a real re-entry alerts again.
+    // Drop cleared issues so a real re-entry alerts again — and so a repaired
+    // issue that genuinely re-enters the dead zone later can be retried.
     for (const n of [...seen]) if (!current.has(n)) seen.delete(n);
+    for (const n of [...tried]) if (!current.has(n)) tried.delete(n);
     deadZoneAlerted.set(repoConfig.name, seen);
+    deadZoneRecoveryAttempted.set(repoConfig.name, tried);
   } catch (err) {
     reconLogger.debug(
       `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,
@@ -882,6 +997,38 @@ async function tryReview(
       reviewFailureCount.set(repoName, 0);
       reviewFailureHitMaxAt.delete(repoName);
       reviewLogger.info(`Review run completed for ${repoName}`);
+
+      // --- Post-condition check ------------------------------------------
+      // The trailer is the agent's CLAIM about what it did. The labels are the
+      // STATE. Verify the claim against the state before believing it: a run
+      // that says `merged=yes` must have left the issue somewhere other than
+      // `pr under review`, because that is where the next phase reads from.
+      //
+      // Checked only for PRs the run claims to have merged — an unmerged PR is
+      // SUPPOSED to still be `pr under review`, so including those would flag
+      // every REQUEST_CHANGES round as an orphan.
+      //
+      // This catches the case the trailer gate cannot: a run that emits a
+      // well-formed trailer but never actually moved the labels. Detection
+      // only; the repair runs in Phase 0 on the next pass (≈1 cycle later),
+      // where it can re-verify first. Alerting here rather than waiting for the
+      // dead-zone sweep skips that path's 15-minute grace window, so a broken
+      // run surfaces in the same cycle that produced it.
+      const mergedPrs = (result.trailers ?? []).filter((t) => t.merged).map((t) => t.pr);
+      if (mergedPrs.length > 0) {
+        const stuck = findIssuesStillUnderReview(repoConfig, candidate.issueNumbers, reviewLogger);
+        if (stuck.length > 0) {
+          reviewLogger.error(
+            `Review post-condition FAILED on ${repoName}: PR(s) #${mergedPrs.join(", #")} reported merged, but issue(s) #${stuck.join(", #")} are still "pr under review" — the run merged without completing the label transition`,
+            { mergedPrs, stuckIssues: stuck },
+          );
+          events?.push({
+            message: `⚠️ ${repoConfig.githubRepo} — review merged PR #${mergedPrs.join(", #")} but left issue(s) #${stuck.join(", #")} at "pr under review". Dead-zone recovery will re-verify next cycle.`,
+            level: "warn",
+          });
+        }
+      }
+
       // Prefer the structured per-PR status (includes deploy SUCCESS/FAILURE);
       // fall back to the summary's first line when no trailer was emitted.
       const outcome = result.statusLine

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { AgentConfig, RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import {
@@ -5,6 +6,7 @@ import {
   findAllApprovedActionableIssues,
   hasPendingRevisions,
   findPendingRevisions,
+  findPRsNeedingReview,
   transitionRevisionLabels,
   transitionImplementationLabels,
   getReferencedIssuesFromOpenPR,
@@ -19,7 +21,7 @@ import {
   stripReadyForProdLabel,
   type PendingRevisionInfo,
 } from "./github.js";
-import { implementApprovedIssues, revisePRFeedback, type ImplementationResult, type RevisionResult } from "./agent.js";
+import { implementApprovedIssues, revisePRFeedback, reviewOpenPRs, type ImplementationResult, type RevisionResult } from "./agent.js";
 import { reconcileRepo, checkLocalBranchDivergence } from "./reconciler.js";
 import { verifyPRExists } from "./github.js";
 import { loadRepoState, saveRepoState } from "./state.js";
@@ -33,6 +35,8 @@ let abortController: AbortController | null = null;
 const failureCount = new Map<string, number>();
 const failureHitMaxAt = new Map<string, number>(); // cycle when max was hit
 const revisionFailureCount = new Map<string, number>();
+const reviewFailureCount = new Map<string, number>();
+const reviewFailureHitMaxAt = new Map<string, number>();
 
 const FAILURE_COOLDOWN_CYCLES = 3; // retry after this many idle cycles
 const lastFailureReason = new Map<string, string>(); // per-repo last failure for retry context
@@ -99,7 +103,21 @@ export async function runCycle(
     }
   }
 
-  // --- Phase 1: Revise PRs with pending review feedback ---
+  // --- Phase 1: Review open feature PRs (invokes the EM /review-all-prs skill) ---
+  // Runs FIRST among the PR-acting phases so it only acts on PRs labeled
+  // `pr under review` in a PRIOR cycle (labels settled). PRs created by THIS
+  // cycle's implement phase wait for next cycle's review — avoids a same-cycle
+  // GitHub-consistency race. The skill owns its own label transitions and merges;
+  // its side effects (`ready for prod release` / `pr pending actions`) feed the
+  // promote and revise phases respectively.
+  for (const repoConfig of config.repos) {
+    const reviewed = await tryReview(repoConfig, config, logger, cycleNumber, events);
+    if (reviewed) {
+      totalProcessed++;
+    }
+  }
+
+  // --- Phase 2: Revise PRs with pending review feedback ---
   for (const repoConfig of config.repos) {
     const revisionInfo = await tryRevision(repoConfig, logger, cycleNumber);
     if (revisionInfo) {
@@ -108,7 +126,7 @@ export async function runCycle(
     }
   }
 
-  // --- Phase 2: Implement approved issues (one batch per repo) ---
+  // --- Phase 3: Implement approved issues (one batch per repo) ---
   for (const repoConfig of config.repos) {
     const result = await tryBatchImplementation(repoConfig, logger, cycleNumber, events);
     if (result) {
@@ -117,7 +135,7 @@ export async function runCycle(
     }
   }
 
-  // --- Phase 3: Reconcile branch drift (main → develop) for any repo with
+  // --- Phase 4: Reconcile branch drift (main → develop) for any repo with
   //    post-promotion merge commits. Runs independently of promotion work so
   //    drift is cleared even when no ready-for-prod issues exist. ---
   for (const repoConfig of config.repos) {
@@ -129,7 +147,7 @@ export async function runCycle(
     }
   }
 
-  // --- Phase 4: Create promotion PRs for repos with ready-for-prod issues ---
+  // --- Phase 5: Create promotion PRs for repos with ready-for-prod issues ---
   for (const repoConfig of config.repos) {
     const promotionResult = tryPromotion(repoConfig, logger, cycleNumber);
     if (promotionResult === "promoted") {
@@ -523,6 +541,82 @@ async function tryRevision(
     }
 
     return null;
+  } finally {
+    implementing = null;
+    abortController = null;
+  }
+}
+
+/**
+ * Review phase: invoke the EM /review-all-prs skill, scoped to one repo, when it
+ * has an open feature PR awaiting review (`pr under review`, no current EM review).
+ *
+ * Unlike implement/revise, the orchestrator does NOT transition labels afterward —
+ * the skill owns its own merges and label transitions at full fidelity. We just
+ * gate, trigger, log, and back off on failure. Every run's full interaction is
+ * written to logs/review/<repo>-cycle<N>-<ts>.log for debugging.
+ *
+ * Returns true when a review run was triggered (regardless of verdict).
+ */
+async function tryReview(
+  repoConfig: RepoConfig,
+  config: AgentConfig,
+  logger: Logger,
+  cycleNumber: number,
+  events?: CycleEvent[],
+): Promise<boolean> {
+  if (!repoConfig.reviewEnabled) return false;
+
+  const repoName = repoConfig.name;
+  const reviewLogger = logger.child({ cycle: cycleNumber, repo: repoName, phase: "review" });
+
+  // Failure back-off with cooldown (mirrors the implement phase).
+  const failures = reviewFailureCount.get(repoName) ?? 0;
+  if (failures >= MAX_RETRIES) {
+    const hitAt = reviewFailureHitMaxAt.get(repoName) ?? cycleNumber;
+    const cyclesSinceMax = cycleNumber - hitAt;
+    if (cyclesSinceMax < FAILURE_COOLDOWN_CYCLES) {
+      reviewLogger.debug(`Skipping ${repoName} review — ${failures} consecutive failures, cooldown ${cyclesSinceMax}/${FAILURE_COOLDOWN_CYCLES}`);
+      return false;
+    }
+    reviewLogger.info(`Review failure cooldown expired for ${repoName} — resetting and retrying`);
+    reviewFailureCount.set(repoName, 0);
+    reviewFailureHitMaxAt.delete(repoName);
+  }
+
+  // Gate: is there an open feature PR awaiting EM review?
+  const candidate = findPRsNeedingReview(repoConfig, config.reviewerLogin, reviewLogger);
+  if (!candidate) {
+    if (failures > 0) reviewFailureCount.set(repoName, 0);
+    return false;
+  }
+
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const transcriptPath = resolve(process.cwd(), "logs", "review", `${repoName}-cycle${cycleNumber}-${ts}.log`);
+
+  implementing = repoName;
+  abortController = new AbortController();
+  reviewLogger.info(`Triggering review for ${repoName} — PR #${candidate.prNumber} (issues: ${candidate.issueNumbers.map(n => `#${n}`).join(", ")}), transcript: ${transcriptPath}`);
+  events?.push({ message: `Reviewing ${repoConfig.githubRepo} PR #${candidate.prNumber} (issues: ${candidate.issueNumbers.map(n => `#${n}`).join(", ")})`, level: "info" });
+
+  try {
+    const result = await reviewOpenPRs(repoConfig, config, reviewLogger, abortController.signal, transcriptPath);
+
+    if (result.success) {
+      reviewFailureCount.set(repoName, 0);
+      reviewFailureHitMaxAt.delete(repoName);
+      const summaryLine = (result.summary || "review completed").split("\n")[0].slice(0, 240);
+      reviewLogger.info(`Review run completed for ${repoName}`);
+      events?.push({ message: `Reviewed ${repoConfig.githubRepo} PR #${candidate.prNumber} — ${summaryLine}`, level: "info" });
+      return true;
+    }
+
+    const newCount = failures + 1;
+    reviewFailureCount.set(repoName, newCount);
+    if (newCount >= MAX_RETRIES) reviewFailureHitMaxAt.set(repoName, cycleNumber);
+    reviewLogger.warn(`Review failed (${newCount}/${MAX_RETRIES}): ${result.error}`);
+    events?.push({ message: `Review failed on ${repoConfig.githubRepo} PR #${candidate.prNumber}: ${result.error}`, level: "error" });
+    return false;
   } finally {
     implementing = null;
     abortController = null;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -43,6 +43,11 @@ const revisionFailureCount = new Map<string, number>();
 const reviewFailureCount = new Map<string, number>();
 const reviewFailureHitMaxAt = new Map<string, number>();
 
+/** Per-repo set of issue numbers already alerted as dead-zoned, so a STANDING
+ *  condition alerts once instead of every reconcile cycle. Cleared per-issue when
+ *  the issue leaves the dead-zone, so a genuine re-entry alerts again. */
+const deadZoneAlerted = new Map<string, Set<number>>();
+
 const FAILURE_COOLDOWN_CYCLES = 3; // retry after this many idle cycles
 const lastFailureReason = new Map<string, string>(); // per-repo last failure for retry context
 
@@ -110,9 +115,21 @@ export async function runCycle(
     // Surface dead-zoned issues: PR merged to develop but the issue is still
     // `pr under review` (post-merge verify failed and no phase recovers it).
     // Detection only — the EM re-verifies and advances/flags by hand.
+    //
+    // ALERT ONCE per (repo, issue). The dead-zone is a STANDING condition, not an
+    // event: it persists every cycle until the EM clears it, so re-emitting each
+    // reconcile pass floods Discord with the identical line (~every 2 min) and
+    // trains the reader to ignore the channel — the alarm defeats itself.
+    // Observed 2026-07-19 on Slashbin-console#661 (Ray: "i keep seeing this
+    // messages"). The warning fires on transition INTO the dead-zone; the entry
+    // clears when the issue leaves it, so a genuine re-entry alerts again.
     try {
       const stuck = findStuckMergedIssues(repoConfig, reconLogger);
+      const seen = deadZoneAlerted.get(repoConfig.name) ?? new Set<number>();
+      const current = new Set(stuck.map((s) => s.issueNumber));
       for (const s of stuck) {
+        if (seen.has(s.issueNumber)) continue; // already alerted; still stuck
+        seen.add(s.issueNumber);
         reconLogger.warn(
           `Dead-zoned issue #${s.issueNumber}: PR #${s.prNumber} merged to ${repoConfig.baseBranch} but issue still "pr under review" — post-merge verify never advanced it`,
           { prUrl: s.prUrl, mergedAt: s.mergedAt },
@@ -122,6 +139,9 @@ export async function runCycle(
           level: "warn",
         });
       }
+      // Drop cleared issues so a real re-entry alerts again.
+      for (const n of [...seen]) if (!current.has(n)) seen.delete(n);
+      deadZoneAlerted.set(repoConfig.name, seen);
     } catch (err) {
       reconLogger.debug(
         `Dead-zone detection failed for ${repoConfig.name}: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -33,7 +33,7 @@ import {
   findIssuesStillUnderReview,
   resolveDeadZone,
   transitionReviewOutcomeLabel,
-  snapshotEmGate,
+  findRevokedEmGates,
   restoreEmGate,
   findOrphanedLifecycleIssues,
   releaseOrphanedLifecycle,
@@ -1177,13 +1177,12 @@ async function tryReview(
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
   const transcriptPath = resolve(process.cwd(), "logs", "review", `${repoName}-cycle${cycleNumber}-${ts}.log`);
 
-  // Snapshot the EM outcome-gate BEFORE the run. `findPRsNeedingReview` already
-  // excludes advanced issues, but it decided that minutes ago; a gate signed
-  // while this run is in flight is invisible to it and gets overwritten by the
-  // run's own label write. Restored in `finally`, so a crash cannot strand it.
-  const gatedBeforeReview = snapshotEmGate(
-    repoConfig.githubRepo, repoConfig.repoPath, candidate.issueNumbers, reviewLogger,
-  );
+  // Mark when this run starts. Any removal of the EM outcome-gate label after
+  // this instant is the run's doing — whether the gate existed beforehand or was
+  // signed while the run was in flight. The second case is the common one,
+  // because the EM signs dev acceptance during the minutes a review takes, and
+  // it is precisely the case a pre-run snapshot cannot see.
+  const reviewStartedAt = new Date().toISOString();
 
   const runAbort = new AbortController();
   activeRuns.set(repoName, runAbort);
@@ -1270,7 +1269,22 @@ async function tryReview(
 
     // Undo any revocation of the EM outcome-gate. In `finally` on purpose: a run
     // that threw or was aborted may still have written labels before it died.
-    const restored = restoreEmGate(repoConfig, gatedBeforeReview, reviewLogger);
+    //
+    // `stripReadyForProd` removes this label legitimately once a promotion PR
+    // takes ownership. When one is open the label is SUPPOSED to be gone, and
+    // restoring it would fight the promotion path — so that case is checked
+    // before any write, and only when something actually looks revoked.
+    const revoked = findRevokedEmGates(
+      repoConfig, candidate.issueNumbers, reviewStartedAt, reviewLogger,
+    );
+    const promotionOwnsIt = revoked.length > 0 &&
+      !!findOpenPromotionPR(repoConfig.githubRepo, "main", repoConfig.repoPath, reviewLogger);
+    if (promotionOwnsIt) {
+      reviewLogger.info(
+        `"${EM_GATE_LABEL}" left removed on #${revoked.join(", #")} — an open promotion PR owns it now.`,
+      );
+    }
+    const restored = promotionOwnsIt ? [] : restoreEmGate(repoConfig, revoked, reviewLogger);
     if (restored.length > 0) {
       events?.push({
         message: `⚠️ ${repoConfig.githubRepo} — the review run removed "${EM_GATE_LABEL}" from issue(s) ${restored.map((n) => `#${n}`).join(", ")}; restored. Promotion would otherwise have stalled silently.`,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -804,7 +804,9 @@ function tryPromotion(
           `Updated promotion PR #${existingPR.number} — added ${missingIssues.length} issue(s): ${missingIssues.map((i) => `#${i.number}`).join(", ")}`
         );
       } else {
-        promoLogger.warn(`Failed to update promotion PR #${existingPR.number}`);
+        promoLogger.error(
+          `Failed to update promotion PR #${existingPR.number} — ${missingIssues.length} dev-verified issue(s) are BLOCKED from production and no promotion PR reflects them. This is not cosmetic: the promote phase found the work and could not act on it.`
+        );
       }
     } else {
       promoLogger.info(`Promotion PR #${existingPR.number} already includes all ${issues.length} issue(s)`);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -205,8 +205,14 @@ function reconcileReviewOutcomeLabels(
   for (const issueNumber of stuck) {
     const ref = byIssue.get(issueNumber);
     if (!ref) {
-      // No merged PR closes it — it is not in the dead zone at all; the PR is
-      // still open and the issue is correctly `pr under review`.
+      // Could not tie this issue to a merged PR. That is EITHER "its PR is still
+      // open, so `pr under review` is correct" OR "the lookup failed" —
+      // findIssuesMergedToBase returns [] for both. Report it rather than pick:
+      // treating a failed lookup as "nothing to fix" is the same silent-skip that
+      // let this whole class of bug run for months. Unresolved keeps the existing
+      // dead-zone warning, which is exactly what fired here before this function
+      // existed, so this is never noisier than the behavior it replaced.
+      unresolved.push(issueNumber);
       continue;
     }
     const trailer = trailers.find((t) => t.pr === ref.prNumber);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -35,6 +35,8 @@ import {
   transitionReviewOutcomeLabel,
   snapshotEmGate,
   restoreEmGate,
+  findOrphanedLifecycleIssues,
+  releaseOrphanedLifecycle,
   EM_GATE_LABEL,
 } from "./github.js";
 import type { ReviewTrailer } from "./agent.js";
@@ -538,6 +540,31 @@ async function runRepoCycle(
     for (const n of [...tried]) if (!current.has(n)) tried.delete(n);
     deadZoneAlerted.set(repoConfig.name, seen);
     deadZoneRecoveryAttempted.set(repoConfig.name, tried);
+
+    // --- Third dead zone: a lifecycle label whose work NEVER LANDED ----------
+    // `pr under review` / `pr pending actions` with no open PR covering the
+    // issue AND nothing merged. The PR was closed unmerged, or an implement run
+    // wrote the label and died before opening one.
+    //
+    // This is the invisible one. `findActionableIssues` skips any issue carrying
+    // a lifecycle label, `tryReview` needs an open PR, `findPendingRevisions`
+    // needs an open PR and returns null at DEBUG level when there is none — so
+    // the issue keeps its `approved` label, is owned by no phase, and produces
+    // no log line anybody reads. It stops existing as far as the pipeline is
+    // concerned, with nothing to indicate it ever stopped.
+    //
+    // Recovery is the inverse of the merged case: nothing exists to verify, so
+    // return it to the queue. Safe precisely BECAUSE nothing merged —
+    // re-implementing cannot duplicate work that was never done.
+    for (const num of findOrphanedLifecycleIssues(repoConfig, reconLogger)) {
+      if (releaseOrphanedLifecycle(repoConfig, num, reconLogger)) {
+        events.push({
+          message: `${repoConfig.githubRepo} #${num} released back to the implement queue — it carried a lifecycle label but no PR covers it and nothing merged, so the work never landed.`,
+          level: "warn",
+        });
+        processed++;
+      }
+    }
 
     // A hold ends when the issue leaves the dead zone (someone set the label or
     // closed it). Prune, or the record outlives the condition and would suppress

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -18,6 +18,8 @@ import {
   checkBranchDrift,
   findOpenSyncPR,
   createSyncPR,
+  findDependencyPRs,
+  tryMergeDependencyPR,
   tryMergeSyncPR,
   countBranchDiffFiles,
   stripReadyForProdLabel,
@@ -607,6 +609,22 @@ async function runRepoCycle(
   if (!(repoConfig.baseBranch === "main" && repoConfig.featureBranch === "main")) {
     if (trySyncDrift(repoConfig, base, cycleNumber)) {
       events.push({ message: `Branch sync on ${repoConfig.githubRepo} (main → develop) — merged`, level: "info" });
+      processed++;
+    }
+  }
+
+  // --- Phase 4b: Merge Dependabot PRs into the development branch once their
+  //    checks are green. They carry no linked issue, so the review phase cannot
+  //    see them and they accumulate against the base branch forever — 8 open
+  //    across the two jerky repos when this was added. Mechanical, like the sync
+  //    merge above: the build and test suite are the whole review. ---
+  if (repoConfig.baseBranch !== "main") {
+    const merged = tryDependencyMerges(repoConfig, base, cycleNumber);
+    if (merged > 0) {
+      events.push({
+        message: `${repoConfig.githubRepo}: merged ${merged} dependency PR(s) into ${repoConfig.baseBranch}`,
+        level: "info",
+      });
       processed++;
     }
   }
@@ -1331,6 +1349,45 @@ function trySyncDrift(
   }
   syncLogger.warn("Failed to create sync PR");
   return false;
+}
+
+/**
+ * Merge every green Dependabot PR into the repo's development branch.
+ *
+ * Guarded to `baseBranch !== "main"` by the caller, and again inside
+ * `tryMergeDependencyPR`: a dependency update must never be merged straight to
+ * a production branch, which is the exact defect `jerky_shipping#237` exists to
+ * close on the producing side. This is the consuming side — it only ever acts on
+ * PRs already aimed at development.
+ *
+ * Returns how many merged, so a quiet cycle stays quiet.
+ */
+function tryDependencyMerges(
+  repoConfig: RepoConfig,
+  logger: Logger,
+  cycleNumber: number,
+): number {
+  const depLogger = logger.child({ cycle: cycleNumber, repo: repoConfig.name, phase: "dependencies" });
+
+  const prs = findDependencyPRs(
+    repoConfig.githubRepo,
+    repoConfig.repoPath,
+    repoConfig.baseBranch,
+    depLogger,
+  );
+  if (prs.length === 0) return 0;
+
+  let merged = 0;
+  for (const pr of prs) {
+    if (tryMergeDependencyPR(repoConfig.githubRepo, pr.number, repoConfig.repoPath, depLogger)) {
+      depLogger.info(`Dependency PR merged — #${pr.number}: ${pr.title}`);
+      merged++;
+    }
+  }
+  if (merged === 0) {
+    depLogger.debug(`${prs.length} dependency PR(s) open, none mergeable this cycle`);
+  }
+  return merged;
 }
 
 function tryPromotion(

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -17,6 +17,7 @@ import {
   checkBranchDrift,
   findOpenSyncPR,
   createSyncPR,
+  tryMergeSyncPR,
   countBranchDiffFiles,
   stripReadyForProdLabel,
   type PendingRevisionInfo,
@@ -912,16 +913,29 @@ function trySyncDrift(
   const drift = checkBranchDrift(repoConfig.githubRepo, repoConfig.repoPath, syncLogger);
   if (!drift || drift.developBehindMain === 0) return false;
 
+  // An already-open sync PR is a RETRY, not a no-op. The merge attempted at
+  // creation runs while required checks are still IN_PROGRESS and is refused, so
+  // "already open" is the normal state a few seconds later — and returning early
+  // here meant it was never merged at all. `develop` then stays behind `main`,
+  // the next promotion PR goes BEHIND, and branch protection refuses it.
+  // (Slashbin-console#779: open 2h48m over ~140 no-op cycles, blocking #782.)
   const existing = findOpenSyncPR(repoConfig.githubRepo, repoConfig.repoPath, syncLogger);
   if (existing) {
-    syncLogger.info(`Sync PR already open — #${existing.number}: ${existing.url}`);
+    if (tryMergeSyncPR(repoConfig.githubRepo, existing.number, repoConfig.repoPath, syncLogger)) {
+      syncLogger.info(`Sync PR merged on retry — #${existing.number}: ${existing.url}`);
+      return true;
+    }
+    syncLogger.info(`Sync PR open, not yet mergeable — #${existing.number}: ${existing.url}`);
     return false;
   }
 
   syncLogger.info(`develop is ${drift.developBehindMain} commit(s) behind main — creating sync PR`);
   const syncUrl = createSyncPR(repoConfig.githubRepo, drift.developBehindMain, repoConfig.repoPath, syncLogger);
   if (syncUrl) {
-    syncLogger.info(`Sync PR created and auto-merged: ${syncUrl}`);
+    // Say what actually happened. This line used to assert "created and
+    // auto-merged" unconditionally, which was false whenever branch protection
+    // refused the create-time merge — i.e. on every protected repo.
+    syncLogger.info(`Sync PR created — ${syncUrl} (merge retried each cycle until checks pass)`);
     return true;
   }
   syncLogger.warn("Failed to create sync PR");

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -23,7 +23,12 @@ import {
 } from "./github.js";
 import { implementApprovedIssues, revisePRFeedback, reviewOpenPRs, type ImplementationResult, type RevisionResult } from "./agent.js";
 import { reconcileRepo, checkLocalBranchDivergence } from "./reconciler.js";
-import { verifyPRExists, findStuckMergedIssues } from "./github.js";
+import {
+  verifyPRExists,
+  findStuckMergedIssues,
+  findIssuesMergedToBase,
+  transitionToReadyForProd,
+} from "./github.js";
 import { loadRepoState, saveRepoState } from "./state.js";
 
 const MAX_RETRIES = 2;
@@ -149,7 +154,7 @@ export async function runCycle(
 
   // --- Phase 3: Implement approved issues (one batch per repo) ---
   for (const repoConfig of config.repos) {
-    const result = await tryBatchImplementation(repoConfig, logger, cycleNumber, events);
+    const result = await tryBatchImplementation(repoConfig, config, logger, cycleNumber, events);
     if (result) {
       totalProcessed++;
       lastResult = result;
@@ -225,13 +230,38 @@ function isResolvedTransientSkip(
   return false;
 }
 
+/** Hard ceiling on the escalating skip back-off — 24h. Beyond this the retry rate
+ *  is already negligible, and we still want an eventual re-check in case the
+ *  world changed (issue body edited, dependency landed). */
+const SKIP_BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Escalating back-off window for the Nth consecutive skip of one issue:
+ * base * 2^(N-1), capped (30m → 1h → 2h → 4h → … → 24h at the default base).
+ *
+ * A FIXED snooze is not a back-off: it never gives up, so an issue that can never
+ * become actionable costs one full Claude session every window, forever
+ * (slashbin-ai-foreman#32). Escalating bounds the cost of ANY repeating skip —
+ * investigation-only issues, blocked-on-external, and merged-work alike.
+ *
+ * skipCount is optional in persisted state (pre-#32 files) — absent reads as the
+ * first skip, i.e. exactly the original single-window behavior.
+ */
+function backoffWindowFor(skipCount: number | undefined, baseMs: number): number {
+  const n = Math.max(1, skipCount ?? 1);
+  const exp = Math.min(n - 1, 10); // 2^10 * 30m ≫ cap; guards against overflow
+  return Math.min(baseMs * 2 ** exp, SKIP_BACKOFF_MAX_MS);
+}
+
 async function tryBatchImplementation(
   repoConfig: RepoConfig,
+  config: AgentConfig,
   logger: Logger,
   cycleNumber: number,
   events?: CycleEvent[]
 ): Promise<ImplementationResult | null> {
   const repoName = repoConfig.name;
+  const skipBackoffMs = config.skipBackoffMs;
   const repoLogger = logger.child({ cycle: cycleNumber, repo: repoName, phase: "implement" });
 
   // Check if this repo has exceeded batch failure retries
@@ -312,7 +342,6 @@ async function tryBatchImplementation(
   // the stale skip entry. This prevents the cache from pinning a dead-zone
   // 30 minutes past an already-applied manual reconcile.
   const skippedMap = repoState.skipped ?? {};
-  const SKIP_BACKOFF_MS = 30 * 60 * 1000; // 30 min
   const now = Date.now();
   const stillBackedOff: { n: number; reason: string }[] = [];
   const resolvedTransient: { n: number; reason: string }[] = [];
@@ -320,7 +349,7 @@ async function tryBatchImplementation(
     const entry = skippedMap[n];
     if (!entry) return true;
     const age = now - new Date(entry.lastSkippedAt).getTime();
-    if (Number.isNaN(age) || age >= SKIP_BACKOFF_MS) return true;
+    if (Number.isNaN(age) || age >= backoffWindowFor(entry.skipCount, skipBackoffMs)) return true;
     if (isResolvedTransientSkip(entry.reason, repoConfig.repoPath, repoLogger)) {
       resolvedTransient.push({ n, reason: entry.reason });
       return true;
@@ -474,13 +503,57 @@ async function tryBatchImplementation(
       // Do NOT increment failureCount — this isn't an error.
       const updatedState = loadRepoState(repoName);
       if (!updatedState.skipped) updatedState.skipped = {};
-      const skippedSet = result.skippedIssues && result.skippedIssues.length > 0
+      let skippedSet = result.skippedIssues && result.skippedIssues.length > 0
         ? result.skippedIssues
         : actionableIssues;
       const reason = result.skipReason ?? "no reason given";
+
+      // --- Case 4 (slashbin-ai-foreman#32): the work is ALREADY MERGED ---------
+      // A skip is only worth retrying if a retry could ever succeed. When the
+      // agent declines because the work is already on `baseBranch`, retrying is
+      // futile BY DEFINITION — the commits exist; no future cycle will produce a
+      // PR for them. Yet the issue keeps `approved` with no lifecycle label, so
+      // it stays "actionable" and we burn a full Claude session every back-off
+      // window, forever (observed: 7+ hours across two repos, 2026-07-13).
+      //
+      // Give the lifecycle its missing EXIT: strip the trigger label and advance
+      // to `ready for prod release`, permanently removing the issue from the
+      // actionable set and handing the EM the signal it already expects. Forward
+      // progress then no longer depends on a human closing the issue promptly.
+      //
+      // Safe because findIssuesMergedToBase() uses the STRICT predicate: only a
+      // merged PR that says it CLOSED the issue counts (never a "related to #N").
+      // On any lookup failure it advances nothing — we under-advance by design.
+      const alreadyMerged = findIssuesMergedToBase(repoConfig, skippedSet, repoLogger);
+      if (alreadyMerged.length > 0) {
+        const mergedNums = alreadyMerged.map((m) => m.issueNumber);
+        transitionToReadyForProd(repoConfig, mergedNums, repoLogger);
+        repoLogger.info(
+          `Advanced ${mergedNums.length} already-merged issue(s) to 'ready for prod release': ${alreadyMerged.map((m) => `#${m.issueNumber} (merged in PR #${m.prNumber})`).join(", ")}`,
+        );
+        events?.push({
+          message: `Advanced ${mergedNums.length} already-merged issue(s) on ${repoConfig.githubRepo} to 'ready for prod release': ${mergedNums.map((n) => `#${n}`).join(", ")}`,
+          level: "info",
+        });
+        // They're out of the actionable set now — no skip record needed, and a
+        // stale one would linger in state forever.
+        for (const n of mergedNums) delete updatedState.skipped[n];
+        skippedSet = skippedSet.filter((n) => !mergedNums.includes(n));
+      }
+      // ------------------------------------------------------------------------
+
       const stamp = new Date().toISOString();
       for (const issueNum of skippedSet) {
-        updatedState.skipped[issueNum] = { lastSkippedAt: stamp, reason };
+        // Escalating per-issue back-off: a fixed snooze never gives up, so a
+        // permanently-unactionable issue costs an agent session every window,
+        // indefinitely. Count the consecutive skips; the filter at the top of
+        // this function widens the window geometrically off this count.
+        const priorCount = updatedState.skipped[issueNum]?.skipCount ?? 0;
+        updatedState.skipped[issueNum] = {
+          lastSkippedAt: stamp,
+          reason,
+          skipCount: priorCount + 1,
+        };
       }
       saveRepoState(repoName, updatedState);
       // Reset the failure counter — an explicit skip is not a failure.

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import type { RepoConfig } from "./config.js";
 import type { Logger } from "./logger.js";
-import { gh, verifyPRExists } from "./github.js";
+import { gh, verifyPRExists, transitionImplementationLabels } from "./github.js";
 
 export interface ReconciliationResult {
   reconciled: boolean;
@@ -252,6 +252,20 @@ export function reconcileRepo(
     }
 
     logger.info(`Reconciliation PR created and verified: ${prUrl}`);
+
+    // Apply `pr under review` to each linked issue. The implement phase normally
+    // does this after a successful PR open, but reconciler PRs are recovery for
+    // orphan commits left by an implementer that crashed (e.g. max-turns) before
+    // labeling — without this, the Review phase's gate (`findPRsNeedingReview`)
+    // never sees the PR and it sits dead-zoned indefinitely.
+    if (issueNumbers.length > 0) {
+      transitionImplementationLabels(
+        config.githubRepo,
+        issueNumbers,
+        config.repoPath,
+        logger,
+      );
+    }
     return { reconciled: true, prUrl, issueNumbers, commitCount: commits.length };
   }
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -9,6 +9,27 @@ export interface ReconciliationResult {
   issueNumbers: number[];
   commitCount: number;
   error?: string;
+  /** Branches the reconciler refused to recreate a PR for — see `RejectedBranch`. */
+  rejected?: RejectedBranch[];
+}
+
+/**
+ * A feature branch carrying commits that were already rejected once.
+ *
+ * The reconciler's whole job is "commits are ahead of base with no open PR, so
+ * make one" — and that is right for orphaned work. It is exactly wrong when the
+ * missing PR is missing *because a human closed it unmerged*. Closing a PR is how
+ * the EM says no; recreating it says no wasn't heard.
+ */
+export interface RejectedBranch {
+  branch: string;
+  /** The closed-unmerged PR whose rejection still stands. */
+  prNumber: number;
+  prUrl: string;
+  /** Branch head — identical to the rejected PR's head, which is why this is a resurrection. */
+  headSha: string;
+  commitCount: number;
+  issueNumbers: number[];
 }
 
 interface OrphanedCommit {
@@ -167,6 +188,52 @@ function hasOpenPR(
   }
 }
 
+/**
+ * The most recent CLOSED-UNMERGED PR for `featureBranch → baseBranch`, with the
+ * head SHA it was closed at.
+ *
+ * `hasOpenPR` deliberately only sees open PRs, which is what lets a rejection
+ * become invisible: the EM closes a PR unmerged, its commits stay on the shared
+ * branch, and one cycle later the reconciler finds "commits ahead, no open PR"
+ * and mints a fresh PR for the work that was just refused. Observed on
+ * jerky_data_receiver (#72 rejected → #74 recreated it, bundled with new work).
+ *
+ * Merged PRs are excluded on purpose — a merged PR is a completed delivery, not a
+ * refusal, and its commits being ahead of base again means something new happened.
+ */
+function findLastClosedUnmergedPR(
+  githubRepo: string,
+  featureBranch: string,
+  baseBranch: string,
+  cwd: string,
+): { number: number; url: string; headSha: string } | null {
+  try {
+    const json = gh([
+      "pr", "list",
+      "--repo", githubRepo,
+      "--head", featureBranch,
+      "--base", baseBranch,
+      "--state", "closed",
+      "--json", "number,url,mergedAt,headRefOid,closedAt",
+      "--limit", "20",
+    ], cwd);
+    const prs: {
+      number: number; url: string;
+      mergedAt: string | null; headRefOid: string; closedAt: string | null;
+    }[] = JSON.parse(json || "[]");
+    const unmerged = prs
+      .filter((p) => !p.mergedAt && p.headRefOid)
+      .sort((a, b) => String(b.closedAt ?? "").localeCompare(String(a.closedAt ?? "")));
+    if (unmerged.length === 0) return null;
+    const latest = unmerged[0];
+    return { number: latest.number, url: latest.url, headSha: latest.headRefOid };
+  } catch {
+    // Unknown, not "no rejection" — the caller treats null as "no guard available"
+    // and proceeds, which preserves the pre-guard behaviour on a gh failure.
+    return null;
+  }
+}
+
 function createReconciliationPR(
   config: RepoConfig,
   headBranch: string,
@@ -248,6 +315,11 @@ export function reconcileRepo(
     return { reconciled: false, issueNumbers: [], commitCount: 0 };
   }
 
+  // Branches whose commits stand rejected. Collected rather than returned early:
+  // one repo can have several feature branches and a rejection on one must not stop
+  // legitimate reconciliation on another.
+  const rejected: RejectedBranch[] = [];
+
   // Check each feature branch for orphaned commits (commits ahead of base with no PR)
   for (const branch of featureBranches) {
     let commits: OrphanedCommit[];
@@ -274,6 +346,40 @@ export function reconcileRepo(
     if (existingPR) {
       logger.debug(`PR already exists for ${branch}: #${existingPR.number} — no reconciliation needed`);
       continue;
+    }
+
+    // Rejection guard: a PR is also "not open" when a human closed it unmerged.
+    // If the branch has not moved since that rejection, recreating the PR would
+    // re-propose the exact diff that was just refused.
+    const lastRejected = findLastClosedUnmergedPR(
+      config.githubRepo, branch, config.baseBranch, config.repoPath,
+    );
+    if (lastRejected) {
+      const headSha = commits[0].hash; // git log lists newest first
+      if (headSha === lastRejected.headSha) {
+        logger.warn(
+          `Not recreating a PR for ${branch} — its last PR (#${lastRejected.number}) was closed unmerged ` +
+          `and the branch has not moved since. The rejected commits are still ahead of ${config.baseBranch}.`,
+          { headSha, rejectedPR: lastRejected.url },
+        );
+        rejected.push({
+          branch,
+          prNumber: lastRejected.number,
+          prUrl: lastRejected.url,
+          headSha,
+          commitCount: commits.length,
+          issueNumbers: extractIssueNumbers(commits),
+        });
+        continue;
+      }
+      // Branch moved since the rejection: new work rides on top of rejected commits.
+      // Reconciling is still correct — someone must see the PR — but the bundle is
+      // not clean, and saying so is the difference between a review and a surprise.
+      logger.warn(
+        `${branch} has new commits on top of a rejected PR (#${lastRejected.number}). ` +
+        `The reconciliation PR will bundle both — the rejected diff has not been reverted.`,
+        { headSha: commits[0].hash, rejectedHead: lastRejected.headSha, rejectedPR: lastRejected.url },
+      );
     }
 
     // Extract issue numbers and create a PR for this branch
@@ -312,8 +418,14 @@ export function reconcileRepo(
         logger,
       );
     }
-    return { reconciled: true, prUrl, issueNumbers, commitCount: commits.length };
+    return {
+      reconciled: true, prUrl, issueNumbers, commitCount: commits.length,
+      ...(rejected.length > 0 ? { rejected } : {}),
+    };
   }
 
-  return { reconciled: false, issueNumbers: [], commitCount: 0 };
+  return {
+    reconciled: false, issueNumbers: [], commitCount: 0,
+    ...(rejected.length > 0 ? { rejected } : {}),
+  };
 }

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -25,6 +25,45 @@ function git(args: string[], cwd: string): string {
   }).trim();
 }
 
+/**
+ * What actually went wrong with a `git` child process.
+ *
+ * `err.message` alone is `Command failed: git fetch origin` — true, and useless.
+ * git puts the reason on stderr, which the helper captures and then nobody reads,
+ * so a broken remote, an auth failure and a killed process all produce the same
+ * sentence. Same defect class as the stderr-masking fixed in `ea60c9d`: a message
+ * that reads as a cause and isn't.
+ *
+ * `signal` matters more than it looks. git runs in the service cgroup, so when
+ * systemd stops the unit its SIGTERM reaches the child while the Foreman is still
+ * draining. The fetch didn't fail — it was cancelled — and reporting that as a
+ * WARN sent one investigation at the clone and the remote before the timestamps
+ * ruled both out.
+ */
+interface GitFailure {
+  error: string;
+  stderr?: string;
+  signal?: string;
+  /** Killed by a shutdown signal rather than failing on its own merits. */
+  cancelled: boolean;
+}
+
+function formatGitError(err: unknown): GitFailure {
+  const e = err as { message?: string; stderr?: unknown; signal?: string | null };
+  const stderr = typeof e?.stderr === "string"
+    ? e.stderr.trim()
+    : Buffer.isBuffer(e?.stderr)
+      ? e.stderr.toString("utf-8").trim()
+      : "";
+  const signal = e?.signal ?? undefined;
+  return {
+    error: e?.message ?? String(err),
+    ...(stderr ? { stderr } : {}),
+    ...(signal ? { signal } : {}),
+    cancelled: signal === "SIGTERM" || signal === "SIGINT",
+  };
+}
+
 export interface LocalBranchDivergence {
   ahead: number;
   behind: number;
@@ -190,9 +229,16 @@ export function reconcileRepo(
   try {
     git(["fetch", "origin"], config.repoPath);
   } catch (err) {
-    logger.warn("git fetch failed, skipping reconciliation", {
-      error: err instanceof Error ? err.message : String(err),
-    });
+    const failure = formatGitError(err);
+    if (failure.cancelled) {
+      // Shutdown, not a fault. The next start reconciles this repo normally.
+      logger.info("Reconciliation cancelled — git fetch was interrupted by shutdown", {
+        repo: config.name,
+        signal: failure.signal,
+      });
+    } else {
+      logger.warn("git fetch failed, skipping reconciliation", { repo: config.name, ...failure });
+    }
     return { reconciled: false, issueNumbers: [], commitCount: 0 };
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -41,6 +41,14 @@ export interface RepoState {
   // deliberate decision must not be rubber-stamped by an automated verdict.
   // Optional for backward compat with state files written before this field existed.
   held?: Record<number, HeldIssue>;
+  // Feature branches whose commits were REJECTED — the last PR for the branch was
+  // closed unmerged and the branch has not moved since. The reconciler refuses to
+  // recreate a PR for them, and this records the head SHA it already alerted on so
+  // a standing rejection is announced ONCE rather than every reconcile pass.
+  // Keyed by branch name; the value is the alerted head SHA, so a NEW commit on the
+  // branch (different SHA) is a fresh condition and alerts again.
+  // Optional for backward compat with state files written before this field existed.
+  rejectedBranches?: Record<string, string>;
 }
 
 interface PersistedState {
@@ -102,6 +110,7 @@ export function loadRepoState(repoName: string): RepoState {
       failed: { ...repo.failed },
       skipped: { ...(repo.skipped ?? {}) },
       held: { ...(repo.held ?? {}) },
+      rejectedBranches: { ...(repo.rejectedBranches ?? {}) },
     };
   }
 
@@ -116,6 +125,7 @@ export function loadRepoState(repoName: string): RepoState {
       failed: { ...migrated.failed },
       skipped: { ...(migrated.skipped ?? {}) },
       held: { ...(migrated.held ?? {}) },
+      rejectedBranches: { ...(migrated.rejectedBranches ?? {}) },
     };
   }
 
@@ -124,6 +134,7 @@ export function loadRepoState(repoName: string): RepoState {
     failed: { ...EMPTY_REPO_STATE.failed },
     skipped: {},
     held: {},
+    rejectedBranches: {},
   };
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,6 +9,12 @@ interface FailedIssue {
 interface SkippedIssue {
   lastSkippedAt: string; // ISO timestamp
   reason: string;
+  // Consecutive times the agent has skipped this issue. Drives the ESCALATING
+  // back-off (a fixed snooze never gives up, so a permanently-unactionable issue
+  // costs one agent session per window forever — slashbin-ai-foreman#32).
+  // Optional for backward compat with state files written before this field existed;
+  // absent is read as 0, i.e. the original single-window behavior.
+  skipCount?: number;
 }
 
 export interface RepoState {

--- a/src/state.ts
+++ b/src/state.ts
@@ -17,6 +17,15 @@ interface SkippedIssue {
   skipCount?: number;
 }
 
+interface HeldIssue {
+  /** ISO timestamp of the review run that declared the hold. */
+  heldAt: string;
+  /** The PR whose review declared it. */
+  prNumber: number;
+  /** Why the reviewer withheld the outcome label, verbatim from the trailer. */
+  reason: string;
+}
+
 export interface RepoState {
   implemented: number[];
   failed: Record<number, FailedIssue>;
@@ -25,6 +34,13 @@ export interface RepoState {
   // applies a back-off so we don't re-attempt every cycle.
   // Optional for backward compat with v2 state files written before this field existed.
   skipped?: Record<number, SkippedIssue>;
+  // Issues whose reviewer DELIBERATELY withheld the outcome label (trailer
+  // `hold=`), e.g. an acceptance criterion that cannot be observed until a later
+  // time boundary. Distinct from a dropped label: the reviewer reported the hold,
+  // so neither the label reconciler nor dead-zone recovery may overwrite it — a
+  // deliberate decision must not be rubber-stamped by an automated verdict.
+  // Optional for backward compat with state files written before this field existed.
+  held?: Record<number, HeldIssue>;
 }
 
 interface PersistedState {
@@ -85,6 +101,7 @@ export function loadRepoState(repoName: string): RepoState {
       implemented: [...repo.implemented],
       failed: { ...repo.failed },
       skipped: { ...(repo.skipped ?? {}) },
+      held: { ...(repo.held ?? {}) },
     };
   }
 
@@ -98,6 +115,7 @@ export function loadRepoState(repoName: string): RepoState {
       implemented: [...migrated.implemented],
       failed: { ...migrated.failed },
       skipped: { ...(migrated.skipped ?? {}) },
+      held: { ...(migrated.held ?? {}) },
     };
   }
 
@@ -105,6 +123,7 @@ export function loadRepoState(repoName: string): RepoState {
     implemented: [...EMPTY_REPO_STATE.implemented],
     failed: { ...EMPTY_REPO_STATE.failed },
     skipped: {},
+    held: {},
   };
 }
 

--- a/test/em-gate.test.mjs
+++ b/test/em-gate.test.mjs
@@ -1,0 +1,78 @@
+// Regression tests for the EM outcome-gate guard.
+//
+// `ready for prod release` is the one label that authorizes production. The
+// review path writes labels through an agent the Foreman cannot intercept, so
+// the guarantee is: whatever the agent does, an EM gate that existed before a
+// review run still exists after it.
+//
+// Origin: Slashbin-io-docs, 2026-08-04. The gate was signed at 20:20:15Z and
+// overwritten with `pr approved` at 20:22:12Z by a review run that had started
+// at 20:11:59Z — before the gate existed, so the trigger-time exclusion in
+// findPRsNeedingReview could not see it. findReadyForProdIssues then returned an
+// empty set, tryPromotion returned early, and the promotion sat stalled for an
+// hour with no error and no log line.
+//
+// Run with `npm test` (node:test, no dependencies) after `npm run build`.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { planEmGateRestore, EM_GATE_LABEL } from "../dist/github.js";
+
+const issue = (number, ...labels) => ({ number, labels: labels.map((name) => ({ name })) });
+
+test("the label constant is the exact string the promotion query filters on", () => {
+  // findReadyForProdIssues filters on this literal; a typo here is a silent stall.
+  assert.equal(EM_GATE_LABEL, "ready for prod release");
+});
+
+test("a gate replaced by 'pr approved' is restored, and the replacement stripped", () => {
+  const steps = planEmGateRestore([225], [issue(225, "feature", "S3", "pr approved")]);
+  assert.deepEqual(steps, [{ number: 225, dropPrApproved: true }]);
+});
+
+test("a gate removed outright is restored without touching anything else", () => {
+  const steps = planEmGateRestore([225], [issue(225, "feature", "S3")]);
+  assert.deepEqual(steps, [{ number: 225, dropPrApproved: false }]);
+});
+
+test("an intact gate is left alone — the healthy path writes nothing", () => {
+  const steps = planEmGateRestore([225], [issue(225, "feature", EM_GATE_LABEL)]);
+  assert.deepEqual(steps, [], "a run that behaved must be bit-for-bit unchanged");
+});
+
+test("a gate alongside 'pr approved' is still intact — no write", () => {
+  // Both labels present is untidy but not a revocation; promotion still finds it.
+  const steps = planEmGateRestore([225], [issue(225, EM_GATE_LABEL, "pr approved")]);
+  assert.deepEqual(steps, []);
+});
+
+test("a closed issue is never re-labeled", () => {
+  // Absent from the OPEN set = closed. Re-labeling would put a finished issue
+  // back in the Foreman's pickup list, which is the no-op-cycle bug in reverse.
+  const steps = planEmGateRestore([225], []);
+  assert.deepEqual(steps, [], "closed issues must not be resurrected by the guard");
+});
+
+test("only issues that carried the gate BEFORE the run are candidates", () => {
+  // #300 has no gate and never had one. The guard must not invent authorization.
+  const steps = planEmGateRestore([225], [issue(225, "pr approved"), issue(300, "pr approved")]);
+  assert.deepEqual(steps, [{ number: 225, dropPrApproved: true }]);
+});
+
+test("an empty before-snapshot can never produce a write", () => {
+  // snapshotEmGate returns [] on any lookup failure. That must mean "restore
+  // nothing", never "restore everything" — a failed read must not manufacture
+  // production authorization.
+  const steps = planEmGateRestore([], [issue(225, "pr approved"), issue(300)]);
+  assert.deepEqual(steps, []);
+});
+
+test("multiple revoked gates in one run are all restored", () => {
+  const steps = planEmGateRestore(
+    [225, 226, 227],
+    [issue(225, "pr approved"), issue(226, EM_GATE_LABEL), issue(227, "pr pending actions")],
+  );
+  assert.deepEqual(steps, [
+    { number: 225, dropPrApproved: true },
+    { number: 227, dropPrApproved: false },
+  ]);
+});

--- a/test/em-gate.test.mjs
+++ b/test/em-gate.test.mjs
@@ -76,3 +76,72 @@ test("multiple revoked gates in one run are all restored", () => {
     { number: 227, dropPrApproved: false },
   ]);
 });
+
+// --- Timeline-based revocation detection -----------------------------------
+//
+// The first version of this guard snapshotted which issues held the gate BEFORE
+// a review run and restored those. It shipped, and then failed on the exact
+// scenario the bug report described. Slashbin-io-docs#269:
+//
+//   13:52:25Z  review run triggered   -> snapshot taken, gate not yet applied
+//   13:57:41Z  EM signs the gate      -> invisible to the snapshot
+//   13:58:20Z  review agent removes it
+//   13:58:xx   guard restores nothing, because its snapshot was empty
+//
+// The rule below is time-symmetric: it asks whether the label was taken away
+// during the window, never whether it existed before the window.
+import { wasGateRevokedSince } from "../dist/github.js";
+
+const RUN_START = Date.parse("2026-08-06T13:52:25Z");
+const ev = (event, name, at) => ({ event, label: { name }, created_at: at });
+
+test("gate signed DURING the run and then removed is detected", () => {
+  // The case the previous guard missed entirely.
+  const events = [
+    ev("labeled", EM_GATE_LABEL, "2026-08-06T13:57:41Z"),
+    ev("unlabeled", EM_GATE_LABEL, "2026-08-06T13:58:20Z"),
+  ];
+  assert.equal(wasGateRevokedSince(events, RUN_START), true);
+});
+
+test("gate that existed before the run and was removed during it is detected", () => {
+  const events = [
+    ev("labeled", EM_GATE_LABEL, "2026-08-06T13:00:00Z"),
+    ev("unlabeled", EM_GATE_LABEL, "2026-08-06T13:58:20Z"),
+  ];
+  assert.equal(wasGateRevokedSince(events, RUN_START), true);
+});
+
+test("a removal BEFORE the run is not this run's doing", () => {
+  // Usually stripReadyForProd on an earlier promotion. Not ours to undo.
+  const events = [ev("unlabeled", EM_GATE_LABEL, "2026-08-06T11:00:00Z")];
+  assert.equal(wasGateRevokedSince(events, RUN_START), false);
+});
+
+test("removing a DIFFERENT label is not a revocation", () => {
+  const events = [
+    ev("unlabeled", "pr under review", "2026-08-06T13:58:20Z"),
+    ev("unlabeled", "approved", "2026-08-06T13:58:20Z"),
+  ];
+  assert.equal(wasGateRevokedSince(events, RUN_START), false);
+});
+
+test("APPLYING the gate during the run is not a revocation", () => {
+  const events = [ev("labeled", EM_GATE_LABEL, "2026-08-06T13:57:41Z")];
+  assert.equal(wasGateRevokedSince(events, RUN_START), false);
+});
+
+test("an empty or unparseable timeline restores nothing", () => {
+  assert.equal(wasGateRevokedSince([], RUN_START), false);
+  assert.equal(wasGateRevokedSince([{ event: "unlabeled" }], RUN_START), false);
+  assert.equal(
+    wasGateRevokedSince([ev("unlabeled", EM_GATE_LABEL, "not-a-date")], RUN_START),
+    false,
+    "an unparseable timestamp must not manufacture a restore",
+  );
+});
+
+test("a removal exactly at the run start counts — the boundary is inclusive", () => {
+  const events = [ev("unlabeled", EM_GATE_LABEL, "2026-08-06T13:52:25Z")];
+  assert.equal(wasGateRevokedSince(events, RUN_START), true);
+});

--- a/test/reconciler-rejection.test.mjs
+++ b/test/reconciler-rejection.test.mjs
@@ -1,0 +1,72 @@
+// Guards for the reconciler's rejection handling and its git error reporting.
+//
+// Source-level assertions on purpose: reconcileRepo shells out to `git` and `gh`
+// against a real clone, so exercising it here would need a fixture repo and a
+// GitHub double. What actually regressed in the incidents these guard was the
+// SHAPE of the code — a lookup that only saw open PRs, and a catch block that
+// threw away the reason — and that is what these pin.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const reconciler = readFileSync(join(root, "src/reconciler.ts"), "utf-8");
+const orchestrator = readFileSync(join(root, "src/orchestrator.ts"), "utf-8");
+const state = readFileSync(join(root, "src/state.ts"), "utf-8");
+
+test("the reconciler looks up closed-unmerged PRs, not only open ones", () => {
+  assert.match(
+    reconciler,
+    /function findLastClosedUnmergedPR/,
+    "no closed-unmerged lookup — a rejected PR is invisible again",
+  );
+  const fn = reconciler.slice(reconciler.indexOf("function findLastClosedUnmergedPR"));
+  assert.match(fn.slice(0, 900), /"--state", "closed"/, "the lookup must query closed PRs");
+  assert.match(fn.slice(0, 900), /!p\.mergedAt/, "a merged PR is a delivery, not a rejection");
+});
+
+test("a branch unchanged since its rejection does not get a new PR", () => {
+  const guard = reconciler.slice(reconciler.indexOf("const lastRejected"));
+  assert.match(guard.slice(0, 1200), /headSha === lastRejected\.headSha/,
+    "the guard must compare the branch head against the rejected head");
+  const beforeCreate = guard.slice(0, guard.indexOf("createReconciliationPR"));
+  assert.match(beforeCreate, /continue;/,
+    "on a match it must skip the branch, not fall through to PR creation");
+});
+
+test("new commits on top of a rejection still reconcile, but say the bundle is dirty", () => {
+  const guard = reconciler.slice(reconciler.indexOf("const lastRejected"));
+  assert.match(guard.slice(0, 2000), /has new commits on top of a rejected PR/,
+    "moving on without a warning is how a rejected diff rides along unnoticed");
+});
+
+test("git failures carry stderr and distinguish a shutdown from a fault", () => {
+  assert.match(reconciler, /function formatGitError/, "no git error formatter");
+  assert.match(reconciler, /cancelled: signal === "SIGTERM" \|\| signal === "SIGINT"/,
+    "a signal-killed fetch must be reported as cancelled, not failed");
+  const fetchCatch = reconciler.slice(reconciler.indexOf('git(["fetch", "origin"]'));
+  assert.match(fetchCatch.slice(0, 900), /if \(failure\.cancelled\)/,
+    "the fetch catch must branch on cancellation");
+  assert.doesNotMatch(
+    fetchCatch.slice(0, 900),
+    /logger\.warn\("git fetch failed[^]*?error: err instanceof Error \? err\.message/,
+    "the message-only warn is what masked the cause",
+  );
+});
+
+test("a rejected branch is announced once per head SHA, not every cycle", () => {
+  assert.match(state, /rejectedBranches\?: Record<string, string>/,
+    "no persisted record — the alert would repeat every reconcile pass");
+  const block = orchestrator.slice(orchestrator.indexOf("for (const r of result.rejected"));
+  assert.match(block.slice(0, 1800), /alreadyAlerted === r\.headSha/,
+    "dedup must key on the head SHA so new commits re-alert");
+  assert.match(block.slice(0, 2400), /saveRepoState/, "the alert must be recorded");
+});
+
+test("the reconciler never force-pushes or resets a shared branch on its own", () => {
+  assert.doesNotMatch(reconciler, /force-with-lease|--force|force=true|reset --hard/,
+    "clearing pollution is destructive and stays a human decision (foreman#24)");
+});

--- a/test/review-trailer.test.mjs
+++ b/test/review-trailer.test.mjs
@@ -125,3 +125,53 @@ test("label mapping never yields the production authorization", () => {
   );
   assert.equal(combos.includes("ready for prod release"), false);
 });
+
+// --- Result extraction --------------------------------------------------
+// Regression guard for the defect that made "no trailer emitted" a lie:
+// extractStreamResult used to return text.slice(0, 2000), and the trailer is
+// required to be the LAST thing the agent emits. Any review with a summary over
+// 2000 chars had its outcome silently cut off, and the caller reported a
+// complete review as having declared nothing. Real case: slashbin-io-worker
+// PR #589 — 3,672-char result, trailer at index 3,571.
+import { extractStreamResult, SUMMARY_DISPLAY_LIMIT } from "../dist/agent.js";
+
+const streamLine = (resultText) =>
+  JSON.stringify({ type: "result", result: resultText, uuid: "x" });
+
+test("extractStreamResult returns the FULL result text, not a truncated copy", () => {
+  const trailer = "FOREMAN_REVIEW pr=#589 verdict=APPROVE merged=yes deploy=SUCCESS";
+  const long = "x".repeat(3500) + "\n\n" + trailer;
+  const out = extractStreamResult(streamLine(long));
+  assert.equal(out.length, long.length, "must not truncate");
+  assert.ok(out.endsWith(trailer));
+});
+
+test("a trailer beyond the display limit still parses", () => {
+  const trailer = "FOREMAN_REVIEW pr=#589 verdict=APPROVE merged=yes deploy=SUCCESS hold=cleanup-not-due-until-0300z";
+  const long = "y".repeat(SUMMARY_DISPLAY_LIMIT + 1500) + "\n\n" + trailer;
+  const full = extractStreamResult(streamLine(long));
+
+  // What the old code did, reproduced to prove the bug is what we think it is.
+  assert.equal(parseReviewTrailerRecords(full.slice(0, SUMMARY_DISPLAY_LIMIT)).length, 0);
+
+  // What the fixed path does.
+  const parsed = parseReviewTrailerRecords(full);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].pr, 589);
+  assert.equal(parsed[0].hold, "cleanup-not-due-until-0300z");
+});
+
+test("extractStreamResult picks the LAST result event and tolerates non-JSON lines", () => {
+  const stdout = [
+    "not json at all",
+    streamLine("first"),
+    "{broken",
+    streamLine("FOREMAN_REVIEW pr=#7 verdict=APPROVE merged=yes deploy=NA"),
+  ].join("\n");
+  const out = extractStreamResult(stdout);
+  assert.equal(parseReviewTrailerRecords(out)[0].pr, 7);
+});
+
+test("no result event => undefined, so the caller can fall back to stdout", () => {
+  assert.equal(extractStreamResult("no json here\n{also not}"), undefined);
+});

--- a/test/review-trailer.test.mjs
+++ b/test/review-trailer.test.mjs
@@ -1,0 +1,127 @@
+// Regression tests for the FOREMAN_REVIEW trailer contract and the label it
+// implies. Run with `npm test` (node:test, no dependencies) after `npm run build`.
+//
+// These cover the two things that must never silently change:
+//   1. the FOUR-FIELD trailer is the published contract — every downstream
+//      reviewer emits it, and the optional `hold=` field must not disturb it;
+//   2. the trailer → label mapping only ever fires on an unambiguous report,
+//      because it now performs a real write instead of only logging.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseReviewTrailerRecords } from "../dist/agent.js";
+import { labelFromTrailer } from "../dist/orchestrator.js";
+
+test("the original four-field trailer parses unchanged (backward compat)", () => {
+  const [t] = parseReviewTrailerRecords(
+    "FOREMAN_REVIEW pr=#100 verdict=APPROVE merged=yes deploy=SUCCESS",
+  );
+  assert.equal(t.pr, 100);
+  assert.equal(t.verdict, "APPROVE");
+  assert.equal(t.merged, true);
+  assert.equal(t.deploy, "SUCCESS");
+  assert.equal(t.hold, undefined, "absent hold must stay undefined, not false-y noise");
+});
+
+test("bare pr number (no #) and lowercase still parse", () => {
+  const [t] = parseReviewTrailerRecords(
+    "foreman_review pr=42 verdict=approve merged=y deploy=na",
+  );
+  assert.equal(t.pr, 42);
+  assert.equal(t.verdict, "APPROVE");
+  assert.equal(t.merged, true);
+  assert.equal(t.deploy, "NA");
+});
+
+test("trailer survives stream-JSON pollution immediately after it", () => {
+  // The Claude CLI emits the trailer inside a single-line JSON envelope; an
+  // unbounded \S+ used to swallow the closing punctuation into `deploy`.
+  const [t] = parseReviewTrailerRecords(
+    'FOREMAN_REVIEW pr=#585 verdict=APPROVE merged=yes deploy=SUCCESS"}],"STOP_REASON":NULL',
+  );
+  assert.equal(t.deploy, "SUCCESS");
+  assert.equal(labelFromTrailer(t), "pr approved");
+});
+
+test("optional hold= is captured as a reason", () => {
+  const [t] = parseReviewTrailerRecords(
+    "FOREMAN_REVIEW pr=#585 verdict=APPROVE merged=yes deploy=SUCCESS hold=criterion-not-observable-until-0300z",
+  );
+  assert.equal(t.deploy, "SUCCESS");
+  assert.equal(t.hold, "criterion-not-observable-until-0300z");
+});
+
+test("hold=no is not a hold", () => {
+  for (const v of ["no", "No", "none", "false", "0"]) {
+    const [t] = parseReviewTrailerRecords(
+      `FOREMAN_REVIEW pr=#1 verdict=APPROVE merged=yes deploy=SUCCESS hold=${v}`,
+    );
+    assert.equal(t.hold, undefined, `hold=${v} must not read as a hold`);
+  }
+});
+
+test("multiple trailers parse independently, mixing old and new forms", () => {
+  const out = parseReviewTrailerRecords(`
+FOREMAN_REVIEW pr=#1 verdict=APPROVE merged=yes deploy=SUCCESS
+FOREMAN_REVIEW pr=#2 verdict=REQUEST_CHANGES merged=no deploy=NA
+FOREMAN_REVIEW pr=#3 verdict=APPROVE merged=yes deploy=SUCCESS hold=waiting-on-window
+`);
+  assert.equal(out.length, 3);
+  assert.equal(out[0].hold, undefined);
+  assert.equal(out[1].merged, false);
+  assert.equal(out[2].hold, "waiting-on-window");
+});
+
+test("label mapping: merged + APPROVE + deploy ok => pr approved", () => {
+  for (const deploy of ["SUCCESS", "NA", "N/A", "NONE", "PASS"]) {
+    assert.equal(
+      labelFromTrailer({ pr: 1, verdict: "APPROVE", merged: true, deploy }),
+      "pr approved",
+      `deploy=${deploy}`,
+    );
+  }
+});
+
+test("label mapping: a failed deploy routes to revise, not approval", () => {
+  assert.equal(
+    labelFromTrailer({ pr: 1, verdict: "APPROVE", merged: true, deploy: "FAILURE" }),
+    "pr pending actions",
+  );
+});
+
+test("label mapping: nothing merged => no write", () => {
+  // An unmerged PR is SUPPOSED to leave the issue at `pr under review`.
+  assert.equal(
+    labelFromTrailer({ pr: 1, verdict: "APPROVE", merged: false, deploy: "NA" }),
+    null,
+  );
+  assert.equal(
+    labelFromTrailer({ pr: 1, verdict: "REQUEST_CHANGES", merged: false, deploy: "NA" }),
+    null,
+  );
+});
+
+test("label mapping: self-contradictory or unknown reports => no write", () => {
+  // Merged but changes requested is incoherent; so is an unrecognised deploy
+  // token. The reconciler repairs a missing write, it never invents one.
+  assert.equal(
+    labelFromTrailer({ pr: 1, verdict: "REQUEST_CHANGES", merged: true, deploy: "SUCCESS" }),
+    null,
+  );
+  assert.equal(
+    labelFromTrailer({ pr: 1, verdict: "APPROVE", merged: true, deploy: "WEIRD" }),
+    null,
+  );
+});
+
+test("label mapping never yields the production authorization", () => {
+  // `ready for prod release` is the EM outcome-gate's signature. No trailer,
+  // however emphatic, may produce it (separation of duties, 2026-07-27).
+  const combos = ["SUCCESS", "FAILURE", "NA", "WEIRD"].flatMap((deploy) =>
+    [true, false].flatMap((merged) =>
+      ["APPROVE", "REQUEST_CHANGES", "NONSENSE"].map((verdict) =>
+        labelFromTrailer({ pr: 1, verdict, merged, deploy }),
+      ),
+    ),
+  );
+  assert.equal(combos.includes("ready for prod release"), false);
+});

--- a/test/revision-escalation.test.mjs
+++ b/test/revision-escalation.test.mjs
@@ -1,0 +1,34 @@
+// Guards for the revision phase's escalation when retries are exhausted.
+//
+// Source-level assertions: the path only fires after two real failed Claude
+// revision runs against a live PR, which no unit test can stage. What regressed
+// was the SHAPE — a cap that returned early at `debug` level and told nobody —
+// so that is what these pin.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const orchestrator = readFileSync(join(root, "src/orchestrator.ts"), "utf-8");
+
+test("exhausted revision retries escalate instead of going quiet", () => {
+  assert.match(orchestrator, /const revisionEscalated = new Set<string>\(\)/,
+    "no escalation bookkeeping");
+  const block = orchestrator.slice(orchestrator.indexOf("newCount >= MAX_RETRIES && !revisionEscalated"));
+  assert.match(block.slice(0, 1500), /events\.push/,
+    "hitting the cap must emit a notifier event, not just a log line");
+  assert.match(block.slice(0, 1500), /level: "error"/, "a stuck PR is an error-level condition");
+  assert.match(block.slice(0, 1500), /pending\.pr\.number/,
+    "the escalation is useless without the PR it is about");
+});
+
+test("the escalation clears when the repo recovers", () => {
+  assert.match(orchestrator, /revisionEscalated\.delete\(repoName\)/,
+    "never clearing means a repo escalates once and then goes silent forever");
+  const deletes = orchestrator.match(/revisionEscalated\.delete\(repoName\)/g) ?? [];
+  assert.ok(deletes.length >= 2,
+    `both recovery paths (success, feedback cleared) must clear it — found ${deletes.length}`);
+});


### PR DESCRIPTION
## What this is

Ten weeks of Foreman work that never left `features`. `develop` and `main` have both
sat on a commit from 2026-06-06 while the daemon ran this branch straight out of the
working tree — so the fixes were live on our host and invisible to everyone who
clones the repo.

39 commits. The body originally described only the first one; this is the full set.

## Reliability

- Per-repo independent loops and one queue per service — a 30-minute build on one
  repo no longer blocks the other nineteen. Bounded by a fleet-wide concurrency
  slot limiter so twenty repos waking together queue rather than opening twenty
  Claude sessions.
- `gh` CLI retries on transient network and 5xx failures (the fleet-stall fix).
- Shutdown drains for the run's real budget instead of a flat 60s.
- Sync-PR merges retry instead of logging "auto-merged" and never trying again.

## Lifecycle correctness

- Terminal state for already-merged approved issues — the escalating back-off
  replaces a flat 30-minute snooze that collided with the poll interval and
  re-picked the same issue every cycle, forever.
- The production authorization is no longer revocable by a review run: the gate
  removal is detected from the issue timeline and restored, rather than snapshotted
  at trigger time and missed.
- The Foreman no longer grants the production authorization itself.
- Review outcome labels are set from the run's own trailer instead of asking an
  agent to remember; an unmatched issue is reported rather than skipped; a clean
  exit is no longer mistaken for a finished review.
- Dead zones closed — an issue always belongs to some phase.
- Promotion PRs are updated via REST (`gh pr edit` is broken by a GitHub
  deprecation), and the promotion stall warning no longer fires on every repo
  forever.

## Diagnostics

- stderr stops impersonating the root cause; implement/revise transcripts are kept.
- One open-issue and one open-PR snapshot per repo per cycle — the discovery phases
  were spending six GraphQL requests each and pushing the shared token over budget.
  The GitHub API budget is now documented.

## New in this branch

- A top-level `model` that cascades to every repo entry, so the fleet's model is one
  dial instead of twenty edits. Per-repo values still win.
- The reconciler no longer recreates a PR a human closed unmerged, and reports the
  rejected branch once per head SHA instead of minting a commingled PR every cycle.
- A killed `git fetch` is reported as a shutdown cancellation rather than a git
  fault, and real failures finally carry git's stderr.
- Exhausted revision retries escalate to Discord with the PR, the issues and the
  last failure reason, instead of skipping silently at debug level forever.

## Verification

- `npm run build` clean, `npm run typecheck` clean, 39 tests pass.
- Backward compatibility: the daemon was restarted on this build and resolved all
  20 repos from the existing unmodified `.ai-agent.json` with identical effective
  values. Clean drain, clean start, cycling with zero errors.
- All new config is optional; existing state files load unchanged.
